### PR TITLE
fix(storybook): unblock build and prevent style override leakage

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -4,6 +4,7 @@ import { provideAnimationsAsync } from '@angular/platform-browser/animations/asy
 import { MAT_ICON_DEFAULT_OPTIONS } from '@angular/material/icon';
 import { TBX_MAT_BANNER_PROVIDER_CONFIG } from '../src/tokens/banner-provider-config.token';
 import { TbxMatBannerSeverityFontIconService } from '../src/services/banner-severity-font-icon.service';
+import { removeStoryOverrideStyleTag } from '../src/components/story-overrides';
 
 // M3 prebuilt theme — provides typography, shape, and state-layer tokens.
 import '@angular/material/prebuilt-themes/azure-blue.css';
@@ -12,6 +13,11 @@ import '../src/styles/_tbx-mat-banners.scss';
 
 const preview: Preview = {
     decorators: [
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (story: () => any) => {
+            removeStoryOverrideStyleTag();
+            return story();
+        },
         applicationConfig({
             providers: [
                 provideAnimationsAsync(),

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,7 +4,7 @@ import tsdoc from 'eslint-plugin-tsdoc';
 
 export default tseslint.config(
     {
-        ignores: ['.claude/', '.storybook/', 'coverage/', 'dist/', 'node_modules/', 'storybook-static/'],
+        ignores: ['.claude/', '.shared-skills/', '.storybook/', 'coverage/', 'dist/', 'node_modules/', 'storybook-static/'],
     },
     ...tseslint.configs.recommended,
     ...angular.configs.tsRecommended,

--- a/src/components/banner-actions-group.stories.ts
+++ b/src/components/banner-actions-group.stories.ts
@@ -78,45 +78,7 @@ const fontIconResolver = {
             }
         </div>
     `,
-    styles: `
-        .harness {
-            font-family: Roboto, sans-serif;
-            padding: 1.5rem;
-        }
-
-        h3 {
-            margin: 1.5rem 0 0.5rem;
-        }
-
-        h3:first-of-type {
-            margin-top: 0;
-        }
-
-        .button-group {
-            display: flex;
-            flex-wrap: wrap;
-            gap: 0.5rem;
-        }
-
-        .state {
-            margin-top: 1rem;
-            font-size: 0.875rem;
-            color: #666;
-        }
-
-        .result-panel {
-            margin-top: 1rem;
-            background: #f0f4ff;
-            border-left: 3px solid #1565c0;
-            padding: 0.5rem 0.75rem;
-        }
-
-        .result-panel pre {
-            font-size: 0.8125rem;
-            margin: 0.25rem 0 0;
-            white-space: pre-wrap;
-        }
-    `,
+    styleUrl: './story-harness.css',
 })
 class BannerActionsHarnessComponent {
     readonly banner = inject(TbxMatBannerService);

--- a/src/components/banner-icon-variants.stories.ts
+++ b/src/components/banner-icon-variants.stories.ts
@@ -3,28 +3,9 @@ import { MatButtonModule } from '@angular/material/button';
 import type { Meta, StoryObj } from '@storybook/angular';
 import { moduleMetadata } from '@storybook/angular';
 import { TbxMatBannerService } from '../services/banner.service';
+import { withCustomProperties, withDefaultProperties } from './story-overrides';
 
 // ─── CSS Custom Property Overrides ───────────────────────────────────────────
-
-const STYLE_TAG_ID = 'tbx-banner-icon-story-overrides';
-
-function withCustomProperties(css: string) {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return (story: () => any) => {
-        document.getElementById(STYLE_TAG_ID)?.remove();
-        if (css) {
-            const style = document.createElement('style');
-            style.id = STYLE_TAG_ID;
-            style.textContent = css;
-            document.head.appendChild(style);
-        }
-        return story();
-    };
-}
-
-function withDefaultProperties() {
-    return withCustomProperties('');
-}
 
 const LARGE_ICON_CSS = `
     html {
@@ -107,32 +88,7 @@ const LARGE_ICON_PULSE_CSS = `
             <p class="state">Active: {{ banner.isActive() }} &middot; Pending: {{ banner.pendingCount() }}</p>
         </div>
     `,
-    styles: `
-        .harness {
-            font-family: Roboto, sans-serif;
-            padding: 1.5rem;
-        }
-
-        h3 {
-            margin: 1.5rem 0 0.5rem;
-        }
-
-        h3:first-of-type {
-            margin-top: 0;
-        }
-
-        .button-group {
-            display: flex;
-            flex-wrap: wrap;
-            gap: 0.5rem;
-        }
-
-        .state {
-            margin-top: 1rem;
-            font-size: 0.875rem;
-            color: #666;
-        }
-    `,
+    styleUrl: './story-harness.css',
 })
 class BannerIconVariantsHarnessComponent {
     readonly banner = inject(TbxMatBannerService);

--- a/src/components/banner-inline.stories.ts
+++ b/src/components/banner-inline.stories.ts
@@ -53,59 +53,7 @@ import { type TbxMatBannerActionsGroupControl } from '../types/banner-actions-gr
             }
         </div>
     `,
-    styles: `
-        .harness {
-            font-family: Roboto, sans-serif;
-            padding: 1.5rem;
-        }
-
-        h3 {
-            margin: 1.5rem 0 0.5rem;
-        }
-
-        h3:first-of-type {
-            margin-top: 0;
-        }
-
-        .button-group {
-            display: flex;
-            flex-wrap: wrap;
-            gap: 0.5rem;
-            margin-bottom: 1rem;
-        }
-
-        .result-panel {
-            margin-top: 1rem;
-            background: #f0f4ff;
-            border-left: 3px solid #1565c0;
-            padding: 0.5rem 0.75rem;
-        }
-
-        .result-panel pre {
-            font-size: 0.8125rem;
-            margin: 0.25rem 0 0;
-            white-space: pre-wrap;
-        }
-
-        .severity-stack {
-            display: flex;
-            flex-direction: column;
-            gap: 0.5rem;
-        }
-
-        .theme-note {
-            font-size: 0.8125rem;
-            color: #888;
-            border-left: 3px solid #ddd;
-            padding: 0.25rem 0.75rem;
-            margin: 0 0 1rem;
-        }
-
-        .dismissed-note {
-            font-size: 0.875rem;
-            color: #666;
-        }
-    `,
+    styleUrl: './story-harness.css',
 })
 class BannerInlineHarnessComponent {
     readonly defaultLevel = TbxMatSeverityLevel.Default;

--- a/src/components/banner-overlay.stories.ts
+++ b/src/components/banner-overlay.stories.ts
@@ -39,40 +39,7 @@ import { TbxMatBannerService } from '../services/banner.service';
             <p class="state">Active: {{ banner.isActive() }} &middot; Pending: {{ banner.pendingCount() }}</p>
         </div>
     `,
-    styles: `
-        .harness {
-            font-family: Roboto, sans-serif;
-            padding: 1.5rem;
-        }
-
-        h3 {
-            margin: 1.5rem 0 0.5rem;
-        }
-
-        h3:first-of-type {
-            margin-top: 0;
-        }
-
-        .button-group {
-            display: flex;
-            flex-wrap: wrap;
-            gap: 0.5rem;
-        }
-
-        .theme-note {
-            font-size: 0.8125rem;
-            color: #888;
-            border-left: 3px solid #ddd;
-            padding: 0.25rem 0.75rem;
-            margin: 0 0 1rem;
-        }
-
-        .state {
-            margin-top: 1rem;
-            font-size: 0.875rem;
-            color: #666;
-        }
-    `,
+    styleUrl: './story-harness.css',
 })
 class BannerOverlayHarnessComponent {
     readonly banner = inject(TbxMatBannerService);

--- a/src/components/banner-svg-icons.stories.ts
+++ b/src/components/banner-svg-icons.stories.ts
@@ -7,28 +7,9 @@ import { MAT_ICON_DEFAULT_OPTIONS } from '@angular/material/icon';
 import { TbxMatBannerService } from '../services/banner.service';
 import { TbxMatBannerSeveritySvgIconService } from '../services/banner-severity-svg-icon.service';
 import { TBX_MAT_BANNER_PROVIDER_CONFIG } from '../tokens/banner-provider-config.token';
+import { withCustomProperties, withDefaultProperties } from './story-overrides';
 
 // ─── CSS Custom Property Overrides ───────────────────────────────────────────
-
-const STYLE_TAG_ID = 'tbx-banner-svg-story-overrides';
-
-function withCustomProperties(css: string) {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return (story: () => any) => {
-        document.getElementById(STYLE_TAG_ID)?.remove();
-        if (css) {
-            const style = document.createElement('style');
-            style.id = STYLE_TAG_ID;
-            style.textContent = css;
-            document.head.appendChild(style);
-        }
-        return story();
-    };
-}
-
-function withDefaultProperties() {
-    return withCustomProperties('');
-}
 
 const LARGE_ICON_CSS = `
     html {
@@ -81,32 +62,7 @@ function withSvgIcons() {
             <p class="state">Active: {{ banner.isActive() }} &middot; Pending: {{ banner.pendingCount() }}</p>
         </div>
     `,
-    styles: `
-        .harness {
-            font-family: Roboto, sans-serif;
-            padding: 1.5rem;
-        }
-
-        h3 {
-            margin: 1.5rem 0 0.5rem;
-        }
-
-        h3:first-of-type {
-            margin-top: 0;
-        }
-
-        .button-group {
-            display: flex;
-            flex-wrap: wrap;
-            gap: 0.5rem;
-        }
-
-        .state {
-            margin-top: 1rem;
-            font-size: 0.875rem;
-            color: #666;
-        }
-    `,
+    styleUrl: './story-harness.css',
 })
 class BannerSvgIconsHarnessComponent {
     readonly banner = inject(TbxMatBannerService);

--- a/src/components/story-harness.css
+++ b/src/components/story-harness.css
@@ -1,0 +1,56 @@
+.harness {
+    font-family: Roboto, sans-serif;
+    padding: 1.5rem;
+}
+
+h3 {
+    margin: 1.5rem 0 0.5rem;
+}
+
+h3:first-of-type {
+    margin-top: 0;
+}
+
+.button-group {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
+.state {
+    margin-top: 1rem;
+    font-size: 0.875rem;
+    color: #666;
+}
+
+.theme-note {
+    font-size: 0.8125rem;
+    color: #888;
+    border-left: 3px solid #ddd;
+    padding: 0.25rem 0.75rem;
+    margin: 0 0 1rem;
+}
+
+.result-panel {
+    margin-top: 1rem;
+    background: #f0f4ff;
+    border-left: 3px solid #1565c0;
+    padding: 0.5rem 0.75rem;
+}
+
+.result-panel pre {
+    font-size: 0.8125rem;
+    margin: 0.25rem 0 0;
+    white-space: pre-wrap;
+}
+
+.severity-stack {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.dismissed-note {
+    font-size: 0.875rem;
+    color: #666;
+}

--- a/src/components/story-overrides.ts
+++ b/src/components/story-overrides.ts
@@ -1,0 +1,33 @@
+/**
+ * Shared Storybook decorators for injecting CSS custom property overrides
+ * into `document.head` for the duration of a story.
+ *
+ * A single shared style tag id is used across all story files so that the
+ * global cleanup decorator in `.storybook/preview.ts` can guarantee a clean
+ * slate before each story renders, preventing overrides from leaking when
+ * navigating between stories.
+ */
+
+export const STORY_OVERRIDE_STYLE_TAG_ID = 'tbx-banner-story-override';
+
+export function removeStoryOverrideStyleTag(): void {
+    document.getElementById(STORY_OVERRIDE_STYLE_TAG_ID)?.remove();
+}
+
+export function withCustomProperties(css: string) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return (story: () => any) => {
+        removeStoryOverrideStyleTag();
+        if (css) {
+            const style = document.createElement('style');
+            style.id = STORY_OVERRIDE_STYLE_TAG_ID;
+            style.textContent = css;
+            document.head.appendChild(style);
+        }
+        return story();
+    };
+}
+
+export function withDefaultProperties() {
+    return withCustomProperties('');
+}


### PR DESCRIPTION
## Summary

- Extract the repeated harness style block from all 5 story files into `src/components/story-harness.css` and reference via `styleUrl`. The Angular Vite JIT plugin base64-encodes inline component styles into virtual asset filenames; the harness block decoded to ~600 chars and exceeded the 255-byte filename limit, breaking `npm run build-storybook` with `ENAMETOOLONG`.
- Centralize the CSS custom-property override decorators in `src/components/story-overrides.ts` behind a single shared style tag id, and add a global cleanup decorator in `.storybook/preview.ts` that strips the tag before every story renders. Previously each variants file declared its own `STYLE_TAG_ID` and only removed its own tag, so overrides like `--tbx-mat-banner-icon-size: 3rem` from "Large Icons" leaked across files and into stories with no override decorator.
- Exclude `.shared-skills/` from ESLint. The aggregator pulls in third-party skill templates (JS and HTML) that fail tsconfig project-service resolution and template-accessibility rules, and they are not part of the package source.

## Test plan

- [ ] `npm run lint` passes
- [ ] `npm run typecheck` passes
- [ ] `npm run build-storybook` completes without `ENAMETOOLONG`
- [ ] In `npm run storybook`, navigate "Banners/Overlay Font Icon Variants/Large Icons" → any other story (e.g. "Banners/Overlay/Default") and confirm icon size resets to default
- [ ] Repeat the navigation across files in both directions (font ↔ svg ↔ overlay/inline/actions) and confirm no style leakage

🤖 Generated with [Claude Code](https://claude.com/claude-code)