### PR TITLE
fix(layout): wrap actions group to a third row in narrow layout

### DIFF
--- a/src/components/banner-inline.stories.ts
+++ b/src/components/banner-inline.stories.ts
@@ -91,6 +91,16 @@ import { type TbxMatBannerActionsGroupControl } from '../types/banner-actions-gr
                 <p class="dismissed-note">Dismissed. <button mat-button (click)="show('controls')">Show again</button></p>
             }
 
+            <h3>Narrow Container (actions wrap to three rows)</h3>
+            <p class="theme-note">This banner is constrained to 500px so the narrow-layout container query kicks in. With enough controls + buttons, the actions row wraps — controls on one row, buttons right-aligned on the next.</p>
+            <div class="narrow-wrapper">
+                @if (!isDismissed('narrowWrap')) {
+                    <tbx-mat-banner [type]="informationLevel" message="Configure notification preferences." [actionsGroup]="narrowWrapControls" (dismissed)="onDismiss('narrowWrap', $event)" />
+                } @else {
+                    <p class="dismissed-note">Dismissed. <button mat-button (click)="show('narrowWrap')">Show again</button></p>
+                }
+            </div>
+
             <h3>No Close Button</h3>
             <tbx-mat-banner [type]="errorLevel" message="This banner cannot be dismissed by the user." [showCloseButton]="false" />
 
@@ -175,6 +185,15 @@ class BannerInlineHarnessComponent {
             ],
             defaultValue: ['email'],
         },
+        { type: 'button', key: 'save', label: 'Save', appearance: 'filled' },
+    ];
+
+    readonly narrowWrapControls: TbxMatBannerActionsGroupControl[] = [
+        { type: 'checkbox', key: 'email', label: 'Email', defaultValue: true },
+        { type: 'checkbox', key: 'sms', label: 'SMS', defaultValue: false },
+        { type: 'checkbox', key: 'push', label: 'Push', defaultValue: true },
+        { type: 'button', key: 'cancel', label: 'Cancel' },
+        { type: 'button', key: 'reset', label: 'Reset', appearance: 'outlined' },
         { type: 'button', key: 'save', label: 'Save', appearance: 'filled' },
     ];
 

--- a/src/components/banner.component.ts
+++ b/src/components/banner.component.ts
@@ -272,8 +272,15 @@ interface ResolvedIcon {
             .tbx-mat-banner-actions {
                 grid-column: 1 / -1;
                 grid-row: 2;
+                flex-wrap: wrap;
+                row-gap: var(--tbx-mat-banner-actions-row-gap, 0.5rem);
                 padding-left: 0;
                 padding-top: var(--tbx-mat-banner-actions-row-gap, 0.5rem);
+            }
+
+            .tbx-mat-banner-controls,
+            .tbx-mat-banner-buttons {
+                flex-shrink: 0;
             }
         }
     `,

--- a/src/components/story-harness.css
+++ b/src/components/story-harness.css
@@ -54,3 +54,8 @@ h3:first-of-type {
     font-size: 0.875rem;
     color: #666;
 }
+
+.narrow-wrapper {
+    max-width: 500px;
+    border: 1px dashed #ccc;
+}


### PR DESCRIPTION
## Summary
- In narrow container layout, enable `flex-wrap` on `.tbx-mat-banner-actions` and mark `.tbx-mat-banner-controls` / `.tbx-mat-banner-buttons` as `flex-shrink: 0` so they wrap as whole units when their combined intrinsic width exceeds the row
- Row layout when wrapping is needed: row 1 message + close, row 2 controls (left-aligned), row 3 buttons (right-aligned via the existing `margin-left: auto`)
- Wide layout untouched
- Adds an inline story case constrained to a 500px wrapper with 6 controls + buttons to make the wrap visually verifiable

## Known limitation
Individual controls that are themselves wider than the container (e.g. a very wide toggle group) will still overflow — that is a content-size problem, not a layout-wrap problem, and is not in scope.

Closes #33

## Test plan
- [x] `npm run storybook` — open Banners/Inline, scroll to "Narrow Container (actions wrap to three rows)"
- [x] Confirm row 1 = message + close, row 2 = three checkboxes (left), row 3 = Cancel/Reset/Save (right)
- [x] Confirm wide-viewport stories (With Action Buttons, With Mixed Controls, etc.) render unchanged
- [x] `npm run lint && npm run typecheck && npm test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)