### PR TITLE
fix(styles): add explicit z-index to banner overlay panel

### DIFF
--- a/src/styles/_tbx-mat-banners.scss
+++ b/src/styles/_tbx-mat-banners.scss
@@ -65,6 +65,7 @@ html {
 
 .tbx-mat-banner-overlay-panel {
     width: 100%;
+    z-index: var(--tbx-mat-banner-overlay-z-index, 1000);
     font-family: var(--mat-sys-body-large-font, Roboto, sans-serif);
     font-size: var(--mat-sys-body-large-size, 0.875rem);
     line-height: var(--mat-sys-body-large-line-height, 1.25rem);


### PR DESCRIPTION
## Summary
- Set an explicit `z-index` on `.tbx-mat-banner-overlay-panel` so the banner has a predictable baseline layer instead of relying on DOM insertion order among sibling CDK overlays
- Expose the value as a new `--tbx-mat-banner-overlay-z-index` CSS variable so consumers can override it (e.g., to sit above or below custom overlays)
- Default of `1000` matches the `cdk-overlay-container` baseline — high enough to sit above stale or non-CDK overlays, low enough that Material modal dialogs still cover banners when opened

Closes #40

## Test plan
- [x] `npm run lint && npm run typecheck && npm test` — all green
- [x] Open any overlay story in Storybook; banner renders as before (purely additive CSS, no visible change in isolation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)