### PR TITLE
refactor(banner-service): replace isDismissing boolean with overlay-ref comparison guard

### DIFF
--- a/src/services/banner.service.spec.ts
+++ b/src/services/banner.service.spec.ts
@@ -506,23 +506,20 @@ describe('TbxMatBannerService', () => {
         });
     });
 
-    describe('isDismissing guard', () => {
-        it('should ignore re-entrant dismissByClose calls', async () => {
+    describe('re-entrant dismiss guard', () => {
+        it('should ignore a second synchronous dismissByClose on the same banner', async () => {
             service.show({ type: TbxMatSeverityLevel.Success, message: 'Test' });
 
             const portal = overlayRefSpy.attach.mock.calls[0][0];
             const data = portal.injector.get(TBX_MAT_BANNER_DATA);
 
-            // First call dismisses normally
             data.dismissByClose();
-            // Second call should be ignored (isDismissing guard)
             data.dismissByClose();
 
-            // Only one dispose call
             expect(overlayRefSpy.dispose).toHaveBeenCalledTimes(1);
         });
 
-        it('should ignore re-entrant dismissByAction calls', async () => {
+        it('should ignore a second synchronous dismissByAction on the same banner', async () => {
             service.show({
                 type: TbxMatSeverityLevel.Success,
                 message: 'Test',
@@ -536,6 +533,95 @@ describe('TbxMatBannerService', () => {
             data.dismissByAction('ok');
 
             expect(overlayRefSpy.dispose).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('stale banner dismiss race', () => {
+        it('dismissByAction on a superseded banner should not dismiss the now-active banner', async () => {
+            const overlayRefA = {
+                attach: vi.fn().mockReturnValue({ instance: mockComponentInstance }),
+                dispose: vi.fn(),
+            };
+            const overlayRefB = {
+                attach: vi.fn().mockReturnValue({ instance: mockComponentInstance }),
+                dispose: vi.fn(),
+            };
+            overlaySpy.create.mockReset();
+            overlaySpy.create.mockReturnValueOnce(overlayRefA).mockReturnValueOnce(overlayRefB);
+
+            const refA = service.show({
+                type: TbxMatSeverityLevel.Success,
+                message: 'A',
+                actionsGroup: [{ type: 'button', key: 'ok', label: 'OK' }],
+            });
+            const refB = service.show({ type: TbxMatSeverityLevel.Success, message: 'B' });
+
+            const portalA = overlayRefA.attach.mock.calls[0][0];
+            const dataA = portalA.injector.get(TBX_MAT_BANNER_DATA);
+
+            service.dismiss();
+
+            expect(overlayRefA.dispose).toHaveBeenCalledTimes(1);
+            expect(overlayRefB.dispose).not.toHaveBeenCalled();
+            expect(service.isActive()).toBe(true);
+
+            // Simulate a stale queued action click firing on A's (destroyed) action button
+            dataA.dismissByAction('ok');
+
+            expect(overlayRefB.dispose).not.toHaveBeenCalled();
+            expect(service.isActive()).toBe(true);
+
+            const resultA = await refA.result;
+            expect(resultA.dismissReason).toBe(TbxMatBannerDismissReason.ProgrammaticDismissCurrent);
+
+            const pending = Symbol('pending');
+            const raceResult = await Promise.race([refB.result, Promise.resolve(pending)]);
+            expect(raceResult).toBe(pending);
+        });
+
+        it('dismissByClose on a superseded banner should not dismiss the now-active banner', async () => {
+            // Distinct overlay refs per overlay.create call so we can tell A and B apart
+            const overlayRefA = {
+                attach: vi.fn().mockReturnValue({ instance: mockComponentInstance }),
+                dispose: vi.fn(),
+            };
+            const overlayRefB = {
+                attach: vi.fn().mockReturnValue({ instance: mockComponentInstance }),
+                dispose: vi.fn(),
+            };
+            overlaySpy.create.mockReset();
+            overlaySpy.create.mockReturnValueOnce(overlayRefA).mockReturnValueOnce(overlayRefB);
+
+            // Show banner A (becomes active) and banner B (queued)
+            const refA = service.show({ type: TbxMatSeverityLevel.Success, message: 'A' });
+            const refB = service.show({ type: TbxMatSeverityLevel.Success, message: 'B' });
+
+            // Capture banner A's DTO while A is still active
+            const portalA = overlayRefA.attach.mock.calls[0][0];
+            const dataA = portalA.injector.get(TBX_MAT_BANNER_DATA);
+
+            // Dismiss A via a different path so banner B becomes active
+            service.dismiss();
+
+            expect(overlayRefA.dispose).toHaveBeenCalledTimes(1);
+            expect(overlayRefB.dispose).not.toHaveBeenCalled();
+            expect(service.isActive()).toBe(true);
+
+            // Simulate a stale queued close click firing on A's (destroyed) close button
+            dataA.dismissByClose();
+
+            // Banner B must not have been dismissed by A's stale callback
+            expect(overlayRefB.dispose).not.toHaveBeenCalled();
+            expect(service.isActive()).toBe(true);
+
+            // Banner A's promise resolved via service.dismiss()
+            const resultA = await refA.result;
+            expect(resultA.dismissReason).toBe(TbxMatBannerDismissReason.ProgrammaticDismissCurrent);
+
+            // Banner B's promise should still be pending
+            const pending = Symbol('pending');
+            const raceResult = await Promise.race([refB.result, Promise.resolve(pending)]);
+            expect(raceResult).toBe(pending);
         });
     });
 

--- a/src/services/banner.service.ts
+++ b/src/services/banner.service.ts
@@ -139,9 +139,6 @@ export class TbxMatBannerService {
     /** Guards against double-resolution of the active result promise. */
     private activeResultResolved = false;
 
-    /** Guards against re-entrant dismiss calls (e.g., double-click on close). */
-    private isDismissing = false;
-
     /** Timeout handle for duration-based auto-dismiss. */
     private durationTimeout: ReturnType<typeof setTimeout> | null = null;
 
@@ -359,7 +356,6 @@ export class TbxMatBannerService {
         this._isActive.set(true);
         this.activeResultResolver = resolveResult;
         this.activeResultResolved = false;
-        this.isDismissing = false;
 
         const duration = this.resolveDuration(config.duration);
 
@@ -392,28 +388,20 @@ export class TbxMatBannerService {
             type: config.type,
             message: config.message,
             dismissByClose: () => {
-                /* v8 ignore start -- re-entrancy guard; not reproducible in synchronous tests */
-                if (this.isDismissing) return;
-                /* v8 ignore stop */
-                this.isDismissing = true;
+                if (this.activeOverlayRef !== overlayRef) return;
                 this.resolveAndCleanup({
                     dismissReason: TbxMatBannerDismissReason.Close,
                     actionsGroupValues: this.activeComponentRef?.collectActionsGroupValues() ?? {},
                 });
-                this.isDismissing = false;
                 this.showNext();
             },
             dismissByAction: (actionKey: string) => {
-                /* v8 ignore start -- re-entrancy guard; not reproducible in synchronous tests */
-                if (this.isDismissing) return;
-                /* v8 ignore stop */
-                this.isDismissing = true;
+                if (this.activeOverlayRef !== overlayRef) return;
                 this.resolveAndCleanup({
                     dismissReason: TbxMatBannerDismissReason.Action,
                     actionKey,
                     actionsGroupValues: this.activeComponentRef?.collectActionsGroupValues() ?? {},
                 });
-                this.isDismissing = false;
                 this.showNext();
             },
             duration,


### PR DESCRIPTION
## Summary
- The `isDismissing` flag in `TbxMatBannerService` was dead code: set to `true`, synchronous cleanup ran, reset to `false` before `showNext()` — leaving no window for reentry to land in, because the event loop is single-threaded. The existing double-call tests passed by coincidence, relying on `resolveAndCleanup`'s idempotency rather than the guard itself. The `/* v8 ignore */` pragmas on the guard branches were the tell that those branches were unreachable.
- Replaced with an overlay-ref capture inside `showNext()`. The DTO's `dismissByClose` and `dismissByAction` closures now compare against `this.activeOverlayRef` on entry and bail silently if the refs don't match. This actually protects the race the original guard was meant to cover: a close/action click queued in the event loop against banner A just before a different path (timeout, programmatic dismiss, `dismissAll`) disposed A and showed B. Without the new guard, that stale callback dismisses B instead.
- Removed the `isDismissing` field, its remaining assignment in `showNext()`, and both `v8 ignore` pragma blocks.

## TDD
- Added two new failing tests (one per callback) exercising the stale-click race, each verified to fail against the old implementation before the fix landed, then passing after.
- Renamed the existing `describe('isDismissing guard', …)` block to `describe('re-entrant dismiss guard', …)` — the old name described an implementation detail that no longer exists. The two double-call tests inside it still pass without modification; they now legitimately exercise the ref-comparison guard (first call nulls `activeOverlayRef`, second call sees the mismatch and bails).

Closes #39

## Test plan
- [ ] `npm run lint && npm run typecheck && npm test` — 109/109 tests pass (was 107)
- [ ] `npm run test:coverage` — `banner.service.ts` at 100% statements / 100% functions / 100% lines / 93.54% branches, above the per-file 75% branch threshold

🤖 Generated with [Claude Code](https://claude.com/claude-code)