### PR TITLE
refactor(banner): migrate inline mode inputs and output to Angular signal inputs

### DIFF
--- a/src/components/banner.component.spec.ts
+++ b/src/components/banner.component.spec.ts
@@ -447,12 +447,12 @@ describe('TbxMatBannerComponent', () => {
             });
 
             const fixture = TestBed.createComponent(TbxMatBannerComponent);
-            fixture.componentInstance.type = TbxMatSeverityLevel.Warning;
-            fixture.componentInstance.message = 'Inline banner';
-            fixture.componentInstance.actionsGroup = [
+            fixture.componentRef.setInput('type', TbxMatSeverityLevel.Warning);
+            fixture.componentRef.setInput('message', 'Inline banner');
+            fixture.componentRef.setInput('actionsGroup', [
                 { type: 'checkbox', key: 'remember', label: 'Remember', defaultValue: false },
                 { type: 'button', key: 'ok', label: 'OK' },
-            ];
+            ]);
             fixture.detectChanges();
             return fixture;
         }
@@ -475,7 +475,7 @@ describe('TbxMatBannerComponent', () => {
             });
 
             const fixture = TestBed.createComponent(TbxMatBannerComponent);
-            fixture.componentInstance.type = TbxMatSeverityLevel.Success;
+            fixture.componentRef.setInput('type', TbxMatSeverityLevel.Success);
             // message, actionsGroup not set — should fall back to '' and []
             fixture.detectChanges();
 
@@ -502,12 +502,12 @@ describe('TbxMatBannerComponent', () => {
             });
 
             const fixture = TestBed.createComponent(TbxMatBannerComponent);
-            fixture.componentInstance.type = TbxMatSeverityLevel.Warning;
-            fixture.componentInstance.message = 'Test';
-            fixture.componentInstance.actionsGroup = [
+            fixture.componentRef.setInput('type', TbxMatSeverityLevel.Warning);
+            fixture.componentRef.setInput('message', 'Test');
+            fixture.componentRef.setInput('actionsGroup', [
                 { type: 'checkbox', key: 'check', label: 'Check' },
                 { type: 'button', key: 'ok', label: 'OK' },
-            ];
+            ]);
             fixture.detectChanges();
 
             expect(fixture.componentInstance.getControlValue('check')).toBe(false);

--- a/src/components/banner.component.ts
+++ b/src/components/banner.component.ts
@@ -1,5 +1,5 @@
 import { NgTemplateOutlet } from '@angular/common';
-import { ChangeDetectionStrategy, Component, computed, EventEmitter, HostBinding, inject, Input, type OnInit, Output, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, HostBinding, inject, input, type OnInit, output, signal } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatCheckboxModule } from '@angular/material/checkbox';
@@ -301,27 +301,27 @@ export class TbxMatBannerComponent implements OnInit {
     // ── Inline mode inputs ──
 
     /** Severity level (inline mode). */
-    @Input() type?: TbxMatSeverityLevel;
+    readonly type = input<TbxMatSeverityLevel>();
 
     /** Message text (inline mode). */
-    @Input() message?: string;
+    readonly message = input<string>();
 
     /** Display duration in milliseconds (inline mode). */
-    @Input() duration?: number;
+    readonly duration = input<number>();
 
     /** Show severity icon (inline mode). */
-    @Input() showSeverityIcon?: boolean;
+    readonly showSeverityIcon = input<boolean>();
 
     /** Show close button (inline mode). */
-    @Input() showCloseButton?: boolean;
+    readonly showCloseButton = input<boolean>();
 
     /** Actions group controls (inline mode). */
-    @Input() actionsGroup?: TbxMatBannerActionsGroupControl[];
+    readonly actionsGroup = input<TbxMatBannerActionsGroupControl[]>();
 
     // ── Inline mode outputs ──
 
     /** Emitted when the banner is dismissed (inline mode). */
-    @Output() readonly dismissed = new EventEmitter<TbxMatBannerResult>();
+    readonly dismissed = output<TbxMatBannerResult>();
 
     // ── Internal state ──
 
@@ -337,15 +337,15 @@ export class TbxMatBannerComponent implements OnInit {
             return this.overlayData;
         }
         return {
-            type: this.type!,
-            message: this.message ?? '',
+            type: this.type()!,
+            message: this.message() ?? '',
             dismissByClose: () => this.dismissInline(TbxMatBannerDismissReason.Close),
             dismissByAction: (actionKey: string) => this.dismissInline(TbxMatBannerDismissReason.Action, actionKey),
-            duration: this.duration ?? 0,
-            showSeverityIcon: this.showSeverityIcon ?? true,
-            showCloseButton: this.showCloseButton ?? true,
+            duration: this.duration() ?? 0,
+            showSeverityIcon: this.showSeverityIcon() ?? true,
+            showCloseButton: this.showCloseButton() ?? true,
             closeIconResolverService: this.config.closeIconResolverService ?? this.defaultCloseIconService,
-            actionsGroup: this.actionsGroup ?? [],
+            actionsGroup: this.actionsGroup() ?? [],
         };
     });
 


### PR DESCRIPTION
## Summary
- Replace the six `@Input()` decorator declarations and the `@Output()` EventEmitter on `TbxMatBannerComponent` with the signal-based `input()` and `output()` functions
- Inputs remain optional (`InputSignal<T | undefined>`) — current semantics preserved
- `dismissed` becomes an `OutputEmitterRef<T>` with the same `.emit()` and `.subscribe()` surface consumers and tests rely on
- Update `resolvedData()` to call inputs as signal getters; non-null assertion on `type` stays to match the existing contract that inline mode callers must supply it
- Update the component spec to use `fixture.componentRef.setInput('name', value)` instead of direct property assignment

## Behavior
No behavior change. Template bindings (`[type]="..."`, `(dismissed)="..."`) work identically; inline stories are unaffected.

Closes #37

## Test plan
- [ ] `npm run lint && npm run typecheck && npm test` — 109/109 tests pass (unchanged)
- [ ] `npm run test:coverage` — `banner.component.ts` at 100% across all metrics (unchanged)
- [ ] Open Banners/Inline stories in Storybook; confirm severity rendering, dismiss event, and control-value collection behave identically

🤖 Generated with [Claude Code](https://claude.com/claude-code)