### PR TITLE
feat(banner): add optional enter/exit animations for overlay banners

### DIFF
--- a/src/components/banner-actions-group.stories.ts
+++ b/src/components/banner-actions-group.stories.ts
@@ -4,6 +4,7 @@ import { MatButtonModule } from '@angular/material/button';
 import type { Meta, StoryObj } from '@storybook/angular';
 import { moduleMetadata } from '@storybook/angular';
 import { TbxMatIconType } from '@teqbench/tbx-mat-icons';
+import { TbxMatBannerAnimation } from '../enums/banner-animation.enum';
 import { TbxMatBannerService } from '../services/banner.service';
 import { type TbxMatBannerResult } from '../models/banner-result.model';
 import { type TbxMatBannerActionsGroupControl } from '../types/banner-actions-group-control.type';
@@ -83,12 +84,14 @@ const fontIconResolver = {
 class BannerActionsHarnessComponent {
     readonly banner = inject(TbxMatBannerService);
     readonly severity = input<string>('warning');
+    readonly verticalPosition = input<'top' | 'bottom'>('top');
+    readonly animation = input<TbxMatBannerAnimation>(TbxMatBannerAnimation.None);
     readonly lastResult = signal<TbxMatBannerResult | null>(null);
 
     private show(message: string, actionsGroup: TbxMatBannerActionsGroupControl[]): void {
         const level = this.severity();
         const method = this.banner[level as keyof TbxMatBannerService] as (msg: string, args?: object) => { result: Promise<TbxMatBannerResult> };
-        const ref = method.call(this.banner, message, { actionsGroup });
+        const ref = method.call(this.banner, message, { actionsGroup, verticalPosition: this.verticalPosition(), animation: this.animation() });
         ref.result.then((result: TbxMatBannerResult) => this.lastResult.set(result));
     }
 
@@ -308,6 +311,16 @@ const meta: Meta<BannerActionsHarnessComponent> = {
             options: ['default', 'success', 'error', 'warning', 'information', 'help'],
             description: 'Severity level for the banner',
         },
+        verticalPosition: {
+            control: 'select',
+            options: ['top', 'bottom'],
+            description: 'Vertical position of the overlay banner',
+        },
+        animation: {
+            control: 'select',
+            options: [TbxMatBannerAnimation.None, TbxMatBannerAnimation.Slide, TbxMatBannerAnimation.Fade],
+            description: 'Enter/exit animation mode',
+        },
     },
 };
 
@@ -316,30 +329,30 @@ type Story = StoryObj<BannerActionsHarnessComponent>;
 
 export const Default: Story = {
     name: 'Default',
-    args: { severity: 'default' },
+    args: { severity: 'default', verticalPosition: 'top', animation: TbxMatBannerAnimation.None },
 };
 
 export const Success: Story = {
     name: 'Success',
-    args: { severity: 'success' },
+    args: { severity: 'success', verticalPosition: 'top', animation: TbxMatBannerAnimation.None },
 };
 
 export const Error: Story = {
     name: 'Error',
-    args: { severity: 'error' },
+    args: { severity: 'error', verticalPosition: 'top', animation: TbxMatBannerAnimation.None },
 };
 
 export const Warning: Story = {
     name: 'Warning',
-    args: { severity: 'warning' },
+    args: { severity: 'warning', verticalPosition: 'top', animation: TbxMatBannerAnimation.None },
 };
 
 export const Information: Story = {
     name: 'Information',
-    args: { severity: 'information' },
+    args: { severity: 'information', verticalPosition: 'top', animation: TbxMatBannerAnimation.None },
 };
 
 export const Help: Story = {
     name: 'Help',
-    args: { severity: 'help' },
+    args: { severity: 'help', verticalPosition: 'top', animation: TbxMatBannerAnimation.None },
 };

--- a/src/components/banner-icon-variants.stories.ts
+++ b/src/components/banner-icon-variants.stories.ts
@@ -2,6 +2,7 @@ import { Component, inject, input } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import type { Meta, StoryObj } from '@storybook/angular';
 import { moduleMetadata } from '@storybook/angular';
+import { TbxMatBannerAnimation } from '../enums/banner-animation.enum';
 import { TbxMatBannerService } from '../services/banner.service';
 import { withCustomProperties, withDefaultProperties } from './story-overrides';
 
@@ -93,6 +94,7 @@ const LARGE_ICON_PULSE_CSS = `
 class BannerIconVariantsHarnessComponent {
     readonly banner = inject(TbxMatBannerService);
     readonly verticalPosition = input<'top' | 'bottom'>('top');
+    readonly animation = input<TbxMatBannerAnimation>(TbxMatBannerAnimation.None);
 
     private readonly messages: Record<string, string> = {
         default: 'This is a default banner.',
@@ -107,11 +109,12 @@ class BannerIconVariantsHarnessComponent {
         const method = this.banner[level as keyof TbxMatBannerService] as (msg: string, args?: object) => void;
         method.call(this.banner, this.messages[level], {
             verticalPosition: this.verticalPosition(),
+            animation: this.animation(),
         });
     }
 
     queueAll(): void {
-        const args = { verticalPosition: this.verticalPosition() };
+        const args = { verticalPosition: this.verticalPosition(), animation: this.animation() };
         this.banner.default('Step 1: This is a default banner.', args);
         this.banner.success('Step 2: Operation completed successfully.', args);
         this.banner.error('Step 3: Something went wrong.', args);
@@ -127,6 +130,18 @@ const meta: Meta<BannerIconVariantsHarnessComponent> = {
     title: 'Banners/Overlay Font Icon Variants',
     component: BannerIconVariantsHarnessComponent,
     decorators: [moduleMetadata({ imports: [BannerIconVariantsHarnessComponent] })],
+    argTypes: {
+        verticalPosition: {
+            control: 'select',
+            options: ['top', 'bottom'],
+            description: 'Vertical position of the overlay banner',
+        },
+        animation: {
+            control: 'select',
+            options: [TbxMatBannerAnimation.None, TbxMatBannerAnimation.Slide, TbxMatBannerAnimation.Fade],
+            description: 'Enter/exit animation mode',
+        },
+    },
 };
 
 export default meta;
@@ -134,16 +149,19 @@ type Story = StoryObj<BannerIconVariantsHarnessComponent>;
 
 export const DefaultIcons: Story = {
     name: 'Default Icons',
+    args: { verticalPosition: 'top', animation: TbxMatBannerAnimation.None },
     decorators: [withDefaultProperties()],
 };
 
 export const LargeIcons: Story = {
     name: 'Large Icons',
+    args: { verticalPosition: 'top', animation: TbxMatBannerAnimation.None },
     decorators: [withCustomProperties(LARGE_ICON_CSS)],
 };
 
 export const StateTransition: Story = {
     name: 'State Transition',
+    args: { verticalPosition: 'top', animation: TbxMatBannerAnimation.None },
     decorators: [withCustomProperties(STATE_TRANSITION_CSS)],
 };
 

--- a/src/components/banner-overlay.stories.ts
+++ b/src/components/banner-overlay.stories.ts
@@ -2,6 +2,7 @@ import { Component, inject, input } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import type { Meta, StoryObj } from '@storybook/angular';
 import { moduleMetadata } from '@storybook/angular';
+import { TbxMatBannerAnimation } from '../enums/banner-animation.enum';
 import { TbxMatBannerService } from '../services/banner.service';
 
 @Component({
@@ -44,6 +45,7 @@ import { TbxMatBannerService } from '../services/banner.service';
 class BannerOverlayHarnessComponent {
     readonly banner = inject(TbxMatBannerService);
     readonly verticalPosition = input<'top' | 'bottom'>('top');
+    readonly animation = input<TbxMatBannerAnimation>(TbxMatBannerAnimation.None);
 
     private readonly messages: Record<string, string> = {
         default: 'This is a default banner with no severity styling.',
@@ -58,11 +60,12 @@ class BannerOverlayHarnessComponent {
         const method = this.banner[level as keyof TbxMatBannerService] as (msg: string, args?: object) => void;
         method.call(this.banner, this.messages[level], {
             verticalPosition: position ?? this.verticalPosition(),
+            animation: this.animation(),
         });
     }
 
     queueDemo(): void {
-        const args = { verticalPosition: this.verticalPosition() };
+        const args = { verticalPosition: this.verticalPosition(), animation: this.animation() };
         this.banner.default('Step 1: This is a default banner.', args);
         this.banner.success('Step 2: Operation completed successfully.', args);
         this.banner.error('Step 3: Something went wrong.', args);
@@ -82,6 +85,11 @@ const meta: Meta<BannerOverlayHarnessComponent> = {
             options: ['top', 'bottom'],
             description: 'Default vertical position of the overlay banner',
         },
+        animation: {
+            control: 'select',
+            options: [TbxMatBannerAnimation.None, TbxMatBannerAnimation.Slide, TbxMatBannerAnimation.Fade],
+            description: 'Enter/exit animation mode',
+        },
     },
 };
 
@@ -91,5 +99,6 @@ type Story = StoryObj<BannerOverlayHarnessComponent>;
 export const Default: Story = {
     args: {
         verticalPosition: 'top',
+        animation: TbxMatBannerAnimation.None,
     },
 };

--- a/src/components/banner-svg-icons.stories.ts
+++ b/src/components/banner-svg-icons.stories.ts
@@ -4,6 +4,7 @@ import type { Meta, StoryObj } from '@storybook/angular';
 import { applicationConfig, moduleMetadata } from '@storybook/angular';
 import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
 import { MAT_ICON_DEFAULT_OPTIONS } from '@angular/material/icon';
+import { TbxMatBannerAnimation } from '../enums/banner-animation.enum';
 import { TbxMatBannerService } from '../services/banner.service';
 import { TbxMatBannerSeveritySvgIconService } from '../services/banner-severity-svg-icon.service';
 import { TBX_MAT_BANNER_PROVIDER_CONFIG } from '../tokens/banner-provider-config.token';
@@ -67,6 +68,7 @@ function withSvgIcons() {
 class BannerSvgIconsHarnessComponent {
     readonly banner = inject(TbxMatBannerService);
     readonly verticalPosition = input<'top' | 'bottom'>('top');
+    readonly animation = input<TbxMatBannerAnimation>(TbxMatBannerAnimation.None);
 
     private readonly messages: Record<string, string> = {
         default: 'This is a default banner.',
@@ -81,11 +83,12 @@ class BannerSvgIconsHarnessComponent {
         const method = this.banner[level as keyof TbxMatBannerService] as (msg: string, args?: object) => void;
         method.call(this.banner, this.messages[level], {
             verticalPosition: this.verticalPosition(),
+            animation: this.animation(),
         });
     }
 
     queueAll(): void {
-        const args = { verticalPosition: this.verticalPosition() };
+        const args = { verticalPosition: this.verticalPosition(), animation: this.animation() };
         this.banner.default('Step 1: This is a default banner.', args);
         this.banner.success('Step 2: Operation completed successfully.', args);
         this.banner.error('Step 3: Something went wrong.', args);
@@ -101,6 +104,18 @@ const meta: Meta<BannerSvgIconsHarnessComponent> = {
     title: 'Banners/Overlay SVG Icons',
     component: BannerSvgIconsHarnessComponent,
     decorators: [moduleMetadata({ imports: [BannerSvgIconsHarnessComponent] }), withSvgIcons()],
+    argTypes: {
+        verticalPosition: {
+            control: 'select',
+            options: ['top', 'bottom'],
+            description: 'Vertical position of the overlay banner',
+        },
+        animation: {
+            control: 'select',
+            options: [TbxMatBannerAnimation.None, TbxMatBannerAnimation.Slide, TbxMatBannerAnimation.Fade],
+            description: 'Enter/exit animation mode',
+        },
+    },
 };
 
 export default meta;
@@ -108,10 +123,12 @@ type Story = StoryObj<BannerSvgIconsHarnessComponent>;
 
 export const Default: Story = {
     name: 'Default SVG Icons',
+    args: { verticalPosition: 'top', animation: TbxMatBannerAnimation.None },
     decorators: [withDefaultProperties()],
 };
 
 export const Large: Story = {
     name: 'Large SVG Icons',
+    args: { verticalPosition: 'top', animation: TbxMatBannerAnimation.None },
     decorators: [withCustomProperties(LARGE_ICON_CSS)],
 };

--- a/src/components/banner.component.spec.ts
+++ b/src/components/banner.component.spec.ts
@@ -24,6 +24,9 @@ function buildData(overrides: Partial<BannerDataDto> = {}): BannerDataDto {
             resolve: () => 'close',
         },
         actionsGroup: [],
+        enterAnimationClass: '',
+        leaveAnimationClass: '',
+        onLeaveAnimationDone: null,
         ...overrides,
     };
 }

--- a/src/components/banner.component.ts
+++ b/src/components/banner.component.ts
@@ -88,6 +88,11 @@ interface ResolvedIcon {
     changeDetection: ChangeDetectionStrategy.OnPush,
     selector: 'tbx-mat-banner',
     imports: [NgTemplateOutlet, FormsModule, MatButtonModule, MatIconModule, MatCheckboxModule, MatSlideToggleModule, MatRadioModule, MatButtonToggleModule],
+    host: {
+        '[animate.enter]': 'resolvedData().enterAnimationClass',
+        '[animate.leave]': 'resolvedData().leaveAnimationClass',
+        '(animate.leave)': 'resolvedData().onLeaveAnimationDone?.()',
+    },
     template: `
         <!-- Shared icon template — handles font ligature vs SVG branching -->
         <ng-template #tbxNgIconTemplate let-icon="icon" let-class="class">
@@ -176,6 +181,7 @@ interface ResolvedIcon {
         :host {
             container-type: inline-size;
             display: grid;
+            box-shadow: var(--tbx-mat-banner-panel-shadow, none);
             grid-template-columns: 1fr auto auto;
             grid-template-rows: auto;
             align-items: center;
@@ -346,6 +352,9 @@ export class TbxMatBannerComponent implements OnInit {
             showCloseButton: this.showCloseButton() ?? true,
             closeIconResolverService: this.config.closeIconResolverService ?? this.defaultCloseIconService,
             actionsGroup: this.actionsGroup() ?? [],
+            enterAnimationClass: '',
+            leaveAnimationClass: '',
+            onLeaveAnimationDone: null,
         };
     });
 

--- a/src/enums/banner-animation.enum.ts
+++ b/src/enums/banner-animation.enum.ts
@@ -1,0 +1,66 @@
+/**
+ * Enter/exit animation mode for overlay banners
+ *
+ * @remarks
+ * Controls the motion applied to an overlay banner as it appears and
+ * disappears. Values map to CSS classes defined in
+ * `src/styles/_tbx-mat-banners.scss` that drive keyframe animations
+ * on the {@link https://material.angular.dev/cdk/overlay/api | CDK Overlay}
+ * panel:
+ *
+ * - `None` — no animation. The banner appears and disappears instantly.
+ * - `Slide` — slides in from the closest viewport edge based on
+ *   {@link TbxMatBannerConfig.verticalPosition}, and slides out the
+ *   same way on dismiss.
+ * - `Fade` — fades in and out via opacity.
+ *
+ * Consumers can tune motion timing via the
+ * `--tbx-mat-banner-anim-duration` and `--tbx-mat-banner-anim-easing`
+ * CSS custom properties. Animations are automatically disabled when
+ * the user has `prefers-reduced-motion: reduce` set at the OS level.
+ *
+ * @usage
+ * Set per banner via {@link TbxMatBannerConfig.animation}, or set an
+ * application-wide default via
+ * {@link TbxMatBannerProviderConfig.defaultAnimation}. A per-banner value
+ * always wins over the provider default.
+ *
+ * @example
+ * ```typescript
+ * this.banner.success('Saved.', { animation: TbxMatBannerAnimation.Slide });
+ * ```
+ *
+ * @category Enums
+ * @displayName Banner Animation
+ * @order 2
+ * @since 1.0.0
+ * @related TbxMatBannerConfig
+ * @related TbxMatBannerProviderConfig
+ *
+ * @public
+ */
+export enum TbxMatBannerAnimation {
+    /**
+     * No animation — banner appears and disappears instantly
+     *
+     * @public
+     */
+    None = 'none',
+
+    /**
+     * Slide in from, and out to, the closest viewport edge
+     *
+     * @remarks
+     * Direction is determined by {@link TbxMatBannerConfig.verticalPosition}.
+     *
+     * @public
+     */
+    Slide = 'slide',
+
+    /**
+     * Fade in and out via opacity
+     *
+     * @public
+     */
+    Fade = 'fade',
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@
  * - {@link TbxMatBannerRef} — returned from service methods with config and result promise.
  * - {@link TbxMatBannerResult} — dismiss result with reason, action key, and collected form values.
  * - {@link TbxMatBannerDismissReason} — enum of dismiss reasons (Action, Close, Timeout, etc.).
+ * - {@link TbxMatBannerAnimation} — enum of overlay animation modes (None, Slide, Fade).
  * - {@link TbxMatBannerConfig} — full config interface for show().
  * - {@link TbxMatBannerConfigArgs} — optional config for convenience methods.
  * - {@link TbxMatBannerActionsGroupControl} — discriminated union of all action control types.
@@ -38,6 +39,7 @@
 
 // Enums
 export { TbxMatSeverityLevel } from '@teqbench/tbx-mat-severity-icons';
+export { TbxMatBannerAnimation } from './enums/banner-animation.enum';
 export { TbxMatBannerDismissReason } from './enums/banner-dismiss-reason.enum';
 
 // Types

--- a/src/models/banner-config.model.ts
+++ b/src/models/banner-config.model.ts
@@ -1,5 +1,6 @@
 import { type TbxMatSeverityLevel } from '@teqbench/tbx-mat-severity-icons';
 
+import { type TbxMatBannerAnimation } from '../enums/banner-animation.enum';
 import { type TbxMatBannerActionsGroupControl } from '../types/banner-actions-group-control.type';
 
 /**
@@ -149,4 +150,24 @@ export interface TbxMatBannerConfig {
      * @public
      */
     readonly verticalPosition?: 'top' | 'bottom';
+
+    /**
+     * Enter/exit animation mode for overlay display
+     *
+     * @remarks
+     * Accepts any member of {@link TbxMatBannerAnimation}:
+     *
+     * - {@link TbxMatBannerAnimation.None} — no animation (default). The banner appears and disappears instantly.
+     * - {@link TbxMatBannerAnimation.Slide} — slides in from the closest viewport edge based on `verticalPosition`, and slides out the same way on dismiss.
+     * - {@link TbxMatBannerAnimation.Fade} — fades in/out via opacity.
+     *
+     * Only applicable to overlay banners created via {@link TbxMatBannerService}.
+     * Consumers can override the default motion timing via the
+     * `--tbx-mat-banner-anim-duration` and `--tbx-mat-banner-anim-easing`
+     * CSS custom properties. Animations are automatically disabled when
+     * the user has `prefers-reduced-motion: reduce` set.
+     *
+     * @public
+     */
+    readonly animation?: TbxMatBannerAnimation;
 }

--- a/src/models/banner-data-dto.model.ts
+++ b/src/models/banner-data-dto.model.ts
@@ -47,4 +47,13 @@ export interface BannerDataDto {
 
     /** Actions group controls to render. */
     readonly actionsGroup: TbxMatBannerActionsGroupControl[];
+
+    /** CSS class for the enter animation (empty string = no animation). */
+    readonly enterAnimationClass: string;
+
+    /** CSS class for the leave animation (empty string = no animation). */
+    readonly leaveAnimationClass: string;
+
+    /** Callback invoked when the leave animation completes. */
+    readonly onLeaveAnimationDone: (() => void) | null;
 }

--- a/src/models/banner-provider-config.model.ts
+++ b/src/models/banner-provider-config.model.ts
@@ -1,6 +1,8 @@
 import { type TbxMatIconResolver, type TbxMatIconType } from '@teqbench/tbx-mat-icons';
 import type { TbxMatSeverityResolver, TbxMatSeverityLevel } from '@teqbench/tbx-mat-severity-icons';
 
+import { type TbxMatBannerAnimation } from '../enums/banner-animation.enum';
+
 /**
  * Configuration for the banner component's injectable dependencies
  *
@@ -93,4 +95,17 @@ export interface TbxMatBannerProviderConfig {
     readonly closeIconResolverService?: TbxMatIconResolver<string> & {
         readonly iconType: TbxMatIconType;
     };
+
+    /**
+     * Default enter/exit animation mode for overlay banners
+     *
+     * @remarks
+     * Applied when a per-banner {@link TbxMatBannerConfig.animation} is not
+     * set. A per-banner value always wins over this default. When both are
+     * omitted, animations are disabled
+     * ({@link TbxMatBannerAnimation.None}).
+     *
+     * @public
+     */
+    readonly defaultAnimation?: TbxMatBannerAnimation;
 }

--- a/src/services/banner.service.spec.ts
+++ b/src/services/banner.service.spec.ts
@@ -77,27 +77,12 @@ describe('TbxMatBannerService', () => {
             expect(overlayRefSpy.attach).toHaveBeenCalledTimes(1);
         });
 
-        it('should apply the correct panel class for each severity', () => {
-            const cases: Array<[TbxMatSeverityLevel, string]> = [
-                [TbxMatSeverityLevel.Default, 'tbx-mat-banner-panel-default'],
-                [TbxMatSeverityLevel.Success, 'tbx-mat-banner-panel-success'],
-                [TbxMatSeverityLevel.Error, 'tbx-mat-banner-panel-error'],
-                [TbxMatSeverityLevel.Warning, 'tbx-mat-banner-panel-warning'],
-                [TbxMatSeverityLevel.Information, 'tbx-mat-banner-panel-information'],
-                [TbxMatSeverityLevel.Help, 'tbx-mat-banner-panel-help'],
-            ];
+        it('should not include severity panel classes in overlay panelClass (severity is on the component host)', () => {
+            service.show({ type: TbxMatSeverityLevel.Success, message: 'test' });
 
-            for (const [type, expectedClass] of cases) {
-                // Dismiss previous by invoking the close callback
-                if (overlaySpy.create.mock.calls.length > 0) {
-                    service.dismiss();
-                }
-
-                service.show({ type, message: 'test' });
-
-                const config = overlaySpy.create.mock.calls.at(-1)![0];
-                expect(config.panelClass).toContain(expectedClass);
-            }
+            const config = overlaySpy.create.mock.calls[0][0];
+            const panelClasses = config.panelClass as string[];
+            expect(panelClasses.some((c) => c.startsWith('tbx-mat-banner-panel-'))).toBe(false);
         });
 
         it('should use default duration (0 = indefinite) when none is provided', () => {
@@ -142,7 +127,6 @@ describe('TbxMatBannerService', () => {
 
             const config = overlaySpy.create.mock.calls[0][0];
             expect(config.panelClass).toContain('my-class');
-            expect(config.panelClass).toContain('tbx-mat-banner-panel-success');
         });
 
         it('should merge consumer panelClass array', () => {
@@ -159,49 +143,49 @@ describe('TbxMatBannerService', () => {
     });
 
     describe('animation class wiring', () => {
-        it('should add tbx-mat-banner-anim-slide to panelClass when animation is Slide', () => {
-            service.show({
-                type: TbxMatSeverityLevel.Success,
-                message: 'Test',
-                animation: TbxMatBannerAnimation.Slide,
-            });
+        it('should set slide enter/leave classes in the DTO when animation is Slide', () => {
+            service.show({ type: TbxMatSeverityLevel.Success, message: 'Test', animation: TbxMatBannerAnimation.Slide });
 
-            const config = overlaySpy.create.mock.calls[0][0];
-            expect(config.panelClass).toContain('tbx-mat-banner-anim-slide');
+            const portal = overlayRefSpy.attach.mock.calls[0][0];
+            const data = portal.injector.get(TBX_MAT_BANNER_DATA);
+            expect(data.enterAnimationClass).toBe('tbx-mat-banner-slide-in-top');
+            expect(data.leaveAnimationClass).toBe('tbx-mat-banner-slide-out-top');
         });
 
-        it('should add tbx-mat-banner-anim-fade to panelClass when animation is Fade', () => {
-            service.show({
-                type: TbxMatSeverityLevel.Success,
-                message: 'Test',
-                animation: TbxMatBannerAnimation.Fade,
-            });
+        it('should use bottom slide classes when verticalPosition is bottom', () => {
+            service.show({ type: TbxMatSeverityLevel.Success, message: 'Test', animation: TbxMatBannerAnimation.Slide, verticalPosition: 'bottom' });
 
-            const config = overlaySpy.create.mock.calls[0][0];
-            expect(config.panelClass).toContain('tbx-mat-banner-anim-fade');
+            const portal = overlayRefSpy.attach.mock.calls[0][0];
+            const data = portal.injector.get(TBX_MAT_BANNER_DATA);
+            expect(data.enterAnimationClass).toBe('tbx-mat-banner-slide-in-bottom');
+            expect(data.leaveAnimationClass).toBe('tbx-mat-banner-slide-out-bottom');
         });
 
-        it('should not add any animation class when animation is None', () => {
-            service.show({
-                type: TbxMatSeverityLevel.Success,
-                message: 'Test',
-                animation: TbxMatBannerAnimation.None,
-            });
+        it('should set fade enter/leave classes in the DTO when animation is Fade', () => {
+            service.show({ type: TbxMatSeverityLevel.Success, message: 'Test', animation: TbxMatBannerAnimation.Fade });
 
-            const config = overlaySpy.create.mock.calls[0][0];
-            const panelClasses = config.panelClass as string[];
-            expect(panelClasses.some((c) => c.startsWith('tbx-mat-banner-anim-'))).toBe(false);
+            const portal = overlayRefSpy.attach.mock.calls[0][0];
+            const data = portal.injector.get(TBX_MAT_BANNER_DATA);
+            expect(data.enterAnimationClass).toBe('tbx-mat-banner-fade-in');
+            expect(data.leaveAnimationClass).toBe('tbx-mat-banner-fade-out');
         });
 
-        it('should not add any animation class when animation is omitted', () => {
-            service.show({
-                type: TbxMatSeverityLevel.Success,
-                message: 'Test',
-            });
+        it('should set empty animation classes when animation is None', () => {
+            service.show({ type: TbxMatSeverityLevel.Success, message: 'Test', animation: TbxMatBannerAnimation.None });
 
-            const config = overlaySpy.create.mock.calls[0][0];
-            const panelClasses = config.panelClass as string[];
-            expect(panelClasses.some((c) => c.startsWith('tbx-mat-banner-anim-'))).toBe(false);
+            const portal = overlayRefSpy.attach.mock.calls[0][0];
+            const data = portal.injector.get(TBX_MAT_BANNER_DATA);
+            expect(data.enterAnimationClass).toBe('');
+            expect(data.leaveAnimationClass).toBe('');
+        });
+
+        it('should set empty animation classes when animation is omitted', () => {
+            service.show({ type: TbxMatSeverityLevel.Success, message: 'Test' });
+
+            const portal = overlayRefSpy.attach.mock.calls[0][0];
+            const data = portal.injector.get(TBX_MAT_BANNER_DATA);
+            expect(data.enterAnimationClass).toBe('');
+            expect(data.leaveAnimationClass).toBe('');
         });
 
         it('should use provider defaultAnimation when config.animation is omitted', () => {
@@ -227,8 +211,9 @@ describe('TbxMatBannerService', () => {
 
             svc.show({ type: TbxMatSeverityLevel.Success, message: 'Test' });
 
-            const config = overlaySpy.create.mock.calls[0][0];
-            expect(config.panelClass).toContain('tbx-mat-banner-anim-slide');
+            const portal = overlayRefSpy.attach.mock.calls[0][0];
+            const data = portal.injector.get(TBX_MAT_BANNER_DATA);
+            expect(data.enterAnimationClass).toBe('tbx-mat-banner-slide-in-top');
         });
 
         it('should prefer per-call config.animation over provider defaultAnimation', () => {
@@ -252,134 +237,66 @@ describe('TbxMatBannerService', () => {
             });
             const svc = TestBed.inject(TbxMatBannerService);
 
-            svc.show({
-                type: TbxMatSeverityLevel.Success,
-                message: 'Test',
-                animation: TbxMatBannerAnimation.Slide,
-            });
+            svc.show({ type: TbxMatSeverityLevel.Success, message: 'Test', animation: TbxMatBannerAnimation.Slide });
 
-            const config = overlaySpy.create.mock.calls[0][0];
-            expect(config.panelClass).toContain('tbx-mat-banner-anim-slide');
-            expect(config.panelClass).not.toContain('tbx-mat-banner-anim-fade');
+            const portal = overlayRefSpy.attach.mock.calls[0][0];
+            const data = portal.injector.get(TBX_MAT_BANNER_DATA);
+            expect(data.enterAnimationClass).toBe('tbx-mat-banner-slide-in-top');
+            expect(data.leaveAnimationClass).toBe('tbx-mat-banner-slide-out-top');
         });
     });
 
     describe('exit animation coordination', () => {
-        it('should add the exit class to the overlay element when dismissByClose is called with Slide animation', () => {
-            service.show({
-                type: TbxMatSeverityLevel.Success,
-                message: 'Test',
-                animation: TbxMatBannerAnimation.Slide,
-            });
+        it('should set onLeaveAnimationDone callback when animation is active', () => {
+            service.show({ type: TbxMatSeverityLevel.Success, message: 'Test', animation: TbxMatBannerAnimation.Slide });
+
+            const portal = overlayRefSpy.attach.mock.calls[0][0];
+            const data = portal.injector.get(TBX_MAT_BANNER_DATA);
+            expect(data.onLeaveAnimationDone).toBeTypeOf('function');
+        });
+
+        it('should set onLeaveAnimationDone to null when animation is none', () => {
+            service.show({ type: TbxMatSeverityLevel.Success, message: 'Test' });
+
+            const portal = overlayRefSpy.attach.mock.calls[0][0];
+            const data = portal.injector.get(TBX_MAT_BANNER_DATA);
+            expect(data.onLeaveAnimationDone).toBeNull();
+        });
+
+        it('should not call showNext immediately on dismissByClose when animation is active', () => {
+            service.show({ type: TbxMatSeverityLevel.Success, message: 'A', animation: TbxMatBannerAnimation.Slide });
+            service.show({ type: TbxMatSeverityLevel.Success, message: 'B' });
 
             const portal = overlayRefSpy.attach.mock.calls[0][0];
             const data = portal.injector.get(TBX_MAT_BANNER_DATA);
 
             data.dismissByClose();
 
-            expect(overlayRefSpy.overlayElement.classList.contains('tbx-mat-banner-anim-slide-out')).toBe(true);
+            // showNext was NOT called — only 1 overlay.create call (for banner A)
+            expect(overlaySpy.create).toHaveBeenCalledTimes(1);
         });
 
-        it('should dispose the overlay after animationend fires', () => {
-            service.show({
-                type: TbxMatSeverityLevel.Success,
-                message: 'Test',
-                animation: TbxMatBannerAnimation.Slide,
-            });
+        it('should call showNext when onLeaveAnimationDone callback is invoked', () => {
+            service.show({ type: TbxMatSeverityLevel.Success, message: 'A', animation: TbxMatBannerAnimation.Slide });
+            service.show({ type: TbxMatSeverityLevel.Success, message: 'B' });
 
             const portal = overlayRefSpy.attach.mock.calls[0][0];
             const data = portal.injector.get(TBX_MAT_BANNER_DATA);
 
             data.dismissByClose();
-            expect(overlayRefSpy.dispose).not.toHaveBeenCalled();
+            expect(overlaySpy.create).toHaveBeenCalledTimes(1);
 
-            overlayRefSpy.overlayElement.dispatchEvent(new Event('animationend'));
-            expect(overlayRefSpy.dispose).toHaveBeenCalledTimes(1);
-        });
-
-        it('should add the exit class when dismissByAction is called with Fade animation', () => {
-            service.show({
-                type: TbxMatSeverityLevel.Success,
-                message: 'Test',
-                animation: TbxMatBannerAnimation.Fade,
-                actionsGroup: [{ type: 'button', key: 'ok', label: 'OK' }],
-            });
-
-            const portal = overlayRefSpy.attach.mock.calls[0][0];
-            const data = portal.injector.get(TBX_MAT_BANNER_DATA);
-
-            data.dismissByAction('ok');
-
-            expect(overlayRefSpy.overlayElement.classList.contains('tbx-mat-banner-anim-fade-out')).toBe(true);
-            expect(overlayRefSpy.dispose).not.toHaveBeenCalled();
-        });
-
-        it('should defer disposal on timeout when animation is enabled', () => {
-            vi.useFakeTimers();
-            service.show({
-                type: TbxMatSeverityLevel.Success,
-                message: 'Test',
-                animation: TbxMatBannerAnimation.Slide,
-                duration: 1000,
-            });
-
-            vi.advanceTimersByTime(1000);
-
-            expect(overlayRefSpy.overlayElement.classList.contains('tbx-mat-banner-anim-slide-out')).toBe(true);
-            expect(overlayRefSpy.dispose).not.toHaveBeenCalled();
-
-            overlayRefSpy.overlayElement.dispatchEvent(new Event('animationend'));
-            expect(overlayRefSpy.dispose).toHaveBeenCalledTimes(1);
-
-            vi.useRealTimers();
+            // Simulate the leave animation completing
+            data.onLeaveAnimationDone!();
+            expect(overlaySpy.create).toHaveBeenCalledTimes(2);
         });
 
         it('should dispose immediately on dismissAll regardless of animation', () => {
-            service.show({
-                type: TbxMatSeverityLevel.Success,
-                message: 'Test',
-                animation: TbxMatBannerAnimation.Slide,
-            });
+            service.show({ type: TbxMatSeverityLevel.Success, message: 'Test', animation: TbxMatBannerAnimation.Slide });
 
             service.dismissAll();
 
             expect(overlayRefSpy.dispose).toHaveBeenCalledTimes(1);
-        });
-
-        it('should force disposal via safety timeout if animationend never fires', () => {
-            vi.useFakeTimers();
-            service.show({
-                type: TbxMatSeverityLevel.Success,
-                message: 'Test',
-                animation: TbxMatBannerAnimation.Slide,
-            });
-
-            const portal = overlayRefSpy.attach.mock.calls[0][0];
-            const data = portal.injector.get(TBX_MAT_BANNER_DATA);
-
-            data.dismissByClose();
-            expect(overlayRefSpy.dispose).not.toHaveBeenCalled();
-
-            // Do NOT dispatch animationend — simulate a browser that skips the animation
-            vi.advanceTimersByTime(1000);
-
-            expect(overlayRefSpy.dispose).toHaveBeenCalledTimes(1);
-            vi.useRealTimers();
-        });
-
-        it('should not dispose the overlay synchronously when animation is enabled', () => {
-            service.show({
-                type: TbxMatSeverityLevel.Success,
-                message: 'Test',
-                animation: TbxMatBannerAnimation.Slide,
-            });
-
-            const portal = overlayRefSpy.attach.mock.calls[0][0];
-            const data = portal.injector.get(TBX_MAT_BANNER_DATA);
-
-            data.dismissByClose();
-
-            expect(overlayRefSpy.dispose).not.toHaveBeenCalled();
         });
     });
 

--- a/src/services/banner.service.spec.ts
+++ b/src/services/banner.service.spec.ts
@@ -16,6 +16,7 @@ describe('TbxMatBannerService', () => {
     let overlayRefSpy: {
         attach: ReturnType<typeof vi.fn>;
         dispose: ReturnType<typeof vi.fn>;
+        overlayElement: HTMLDivElement;
     };
     let overlaySpy: {
         create: ReturnType<typeof vi.fn>;
@@ -33,6 +34,7 @@ describe('TbxMatBannerService', () => {
         overlayRefSpy = {
             attach: vi.fn().mockReturnValue({ instance: mockComponentInstance }),
             dispose: vi.fn(),
+            overlayElement: document.createElement('div'),
         };
 
         const positionStrategySpy = {
@@ -259,6 +261,125 @@ describe('TbxMatBannerService', () => {
             const config = overlaySpy.create.mock.calls[0][0];
             expect(config.panelClass).toContain('tbx-mat-banner-anim-slide');
             expect(config.panelClass).not.toContain('tbx-mat-banner-anim-fade');
+        });
+    });
+
+    describe('exit animation coordination', () => {
+        it('should add the exit class to the overlay element when dismissByClose is called with Slide animation', () => {
+            service.show({
+                type: TbxMatSeverityLevel.Success,
+                message: 'Test',
+                animation: TbxMatBannerAnimation.Slide,
+            });
+
+            const portal = overlayRefSpy.attach.mock.calls[0][0];
+            const data = portal.injector.get(TBX_MAT_BANNER_DATA);
+
+            data.dismissByClose();
+
+            expect(overlayRefSpy.overlayElement.classList.contains('tbx-mat-banner-anim-slide-out')).toBe(true);
+        });
+
+        it('should dispose the overlay after animationend fires', () => {
+            service.show({
+                type: TbxMatSeverityLevel.Success,
+                message: 'Test',
+                animation: TbxMatBannerAnimation.Slide,
+            });
+
+            const portal = overlayRefSpy.attach.mock.calls[0][0];
+            const data = portal.injector.get(TBX_MAT_BANNER_DATA);
+
+            data.dismissByClose();
+            expect(overlayRefSpy.dispose).not.toHaveBeenCalled();
+
+            overlayRefSpy.overlayElement.dispatchEvent(new Event('animationend'));
+            expect(overlayRefSpy.dispose).toHaveBeenCalledTimes(1);
+        });
+
+        it('should add the exit class when dismissByAction is called with Fade animation', () => {
+            service.show({
+                type: TbxMatSeverityLevel.Success,
+                message: 'Test',
+                animation: TbxMatBannerAnimation.Fade,
+                actionsGroup: [{ type: 'button', key: 'ok', label: 'OK' }],
+            });
+
+            const portal = overlayRefSpy.attach.mock.calls[0][0];
+            const data = portal.injector.get(TBX_MAT_BANNER_DATA);
+
+            data.dismissByAction('ok');
+
+            expect(overlayRefSpy.overlayElement.classList.contains('tbx-mat-banner-anim-fade-out')).toBe(true);
+            expect(overlayRefSpy.dispose).not.toHaveBeenCalled();
+        });
+
+        it('should defer disposal on timeout when animation is enabled', () => {
+            vi.useFakeTimers();
+            service.show({
+                type: TbxMatSeverityLevel.Success,
+                message: 'Test',
+                animation: TbxMatBannerAnimation.Slide,
+                duration: 1000,
+            });
+
+            vi.advanceTimersByTime(1000);
+
+            expect(overlayRefSpy.overlayElement.classList.contains('tbx-mat-banner-anim-slide-out')).toBe(true);
+            expect(overlayRefSpy.dispose).not.toHaveBeenCalled();
+
+            overlayRefSpy.overlayElement.dispatchEvent(new Event('animationend'));
+            expect(overlayRefSpy.dispose).toHaveBeenCalledTimes(1);
+
+            vi.useRealTimers();
+        });
+
+        it('should dispose immediately on dismissAll regardless of animation', () => {
+            service.show({
+                type: TbxMatSeverityLevel.Success,
+                message: 'Test',
+                animation: TbxMatBannerAnimation.Slide,
+            });
+
+            service.dismissAll();
+
+            expect(overlayRefSpy.dispose).toHaveBeenCalledTimes(1);
+        });
+
+        it('should force disposal via safety timeout if animationend never fires', () => {
+            vi.useFakeTimers();
+            service.show({
+                type: TbxMatSeverityLevel.Success,
+                message: 'Test',
+                animation: TbxMatBannerAnimation.Slide,
+            });
+
+            const portal = overlayRefSpy.attach.mock.calls[0][0];
+            const data = portal.injector.get(TBX_MAT_BANNER_DATA);
+
+            data.dismissByClose();
+            expect(overlayRefSpy.dispose).not.toHaveBeenCalled();
+
+            // Do NOT dispatch animationend — simulate a browser that skips the animation
+            vi.advanceTimersByTime(1000);
+
+            expect(overlayRefSpy.dispose).toHaveBeenCalledTimes(1);
+            vi.useRealTimers();
+        });
+
+        it('should not dispose the overlay synchronously when animation is enabled', () => {
+            service.show({
+                type: TbxMatSeverityLevel.Success,
+                message: 'Test',
+                animation: TbxMatBannerAnimation.Slide,
+            });
+
+            const portal = overlayRefSpy.attach.mock.calls[0][0];
+            const data = portal.injector.get(TBX_MAT_BANNER_DATA);
+
+            data.dismissByClose();
+
+            expect(overlayRefSpy.dispose).not.toHaveBeenCalled();
         });
     });
 

--- a/src/services/banner.service.spec.ts
+++ b/src/services/banner.service.spec.ts
@@ -7,6 +7,7 @@ import { TbxMatBannerService } from './banner.service';
 import { TbxMatBannerSeverityFontIconService } from './banner-severity-font-icon.service';
 import { TBX_MAT_BANNER_PROVIDER_CONFIG } from '../tokens/banner-provider-config.token';
 import { TBX_MAT_BANNER_DATA } from '../tokens/banner-data.token';
+import { TbxMatBannerAnimation } from '../enums/banner-animation.enum';
 import { TbxMatBannerDismissReason } from '../enums/banner-dismiss-reason.enum';
 import { BANNER_DEFAULT_DURATION_MS } from '../constants/banner.constants';
 
@@ -152,6 +153,112 @@ describe('TbxMatBannerService', () => {
             const config = overlaySpy.create.mock.calls[0][0];
             expect(config.panelClass).toContain('class-a');
             expect(config.panelClass).toContain('class-b');
+        });
+    });
+
+    describe('animation class wiring', () => {
+        it('should add tbx-mat-banner-anim-slide to panelClass when animation is Slide', () => {
+            service.show({
+                type: TbxMatSeverityLevel.Success,
+                message: 'Test',
+                animation: TbxMatBannerAnimation.Slide,
+            });
+
+            const config = overlaySpy.create.mock.calls[0][0];
+            expect(config.panelClass).toContain('tbx-mat-banner-anim-slide');
+        });
+
+        it('should add tbx-mat-banner-anim-fade to panelClass when animation is Fade', () => {
+            service.show({
+                type: TbxMatSeverityLevel.Success,
+                message: 'Test',
+                animation: TbxMatBannerAnimation.Fade,
+            });
+
+            const config = overlaySpy.create.mock.calls[0][0];
+            expect(config.panelClass).toContain('tbx-mat-banner-anim-fade');
+        });
+
+        it('should not add any animation class when animation is None', () => {
+            service.show({
+                type: TbxMatSeverityLevel.Success,
+                message: 'Test',
+                animation: TbxMatBannerAnimation.None,
+            });
+
+            const config = overlaySpy.create.mock.calls[0][0];
+            const panelClasses = config.panelClass as string[];
+            expect(panelClasses.some((c) => c.startsWith('tbx-mat-banner-anim-'))).toBe(false);
+        });
+
+        it('should not add any animation class when animation is omitted', () => {
+            service.show({
+                type: TbxMatSeverityLevel.Success,
+                message: 'Test',
+            });
+
+            const config = overlaySpy.create.mock.calls[0][0];
+            const panelClasses = config.panelClass as string[];
+            expect(panelClasses.some((c) => c.startsWith('tbx-mat-banner-anim-'))).toBe(false);
+        });
+
+        it('should use provider defaultAnimation when config.animation is omitted', () => {
+            TestBed.resetTestingModule();
+            TestBed.configureTestingModule({
+                providers: [
+                    TbxMatBannerService,
+                    { provide: Overlay, useValue: overlaySpy },
+                    {
+                        provide: TBX_MAT_FONT_ICON_DEFAULT_FONT_SET,
+                        useValue: TBX_MAT_ICON_FONT_SET_MATERIAL_SYMBOLS_ROUNDED,
+                    },
+                    {
+                        provide: TBX_MAT_BANNER_PROVIDER_CONFIG,
+                        useFactory: () => ({
+                            severityIconResolverService: new TbxMatBannerSeverityFontIconService(),
+                            defaultAnimation: TbxMatBannerAnimation.Slide,
+                        }),
+                    },
+                ],
+            });
+            const svc = TestBed.inject(TbxMatBannerService);
+
+            svc.show({ type: TbxMatSeverityLevel.Success, message: 'Test' });
+
+            const config = overlaySpy.create.mock.calls[0][0];
+            expect(config.panelClass).toContain('tbx-mat-banner-anim-slide');
+        });
+
+        it('should prefer per-call config.animation over provider defaultAnimation', () => {
+            TestBed.resetTestingModule();
+            TestBed.configureTestingModule({
+                providers: [
+                    TbxMatBannerService,
+                    { provide: Overlay, useValue: overlaySpy },
+                    {
+                        provide: TBX_MAT_FONT_ICON_DEFAULT_FONT_SET,
+                        useValue: TBX_MAT_ICON_FONT_SET_MATERIAL_SYMBOLS_ROUNDED,
+                    },
+                    {
+                        provide: TBX_MAT_BANNER_PROVIDER_CONFIG,
+                        useFactory: () => ({
+                            severityIconResolverService: new TbxMatBannerSeverityFontIconService(),
+                            defaultAnimation: TbxMatBannerAnimation.Fade,
+                        }),
+                    },
+                ],
+            });
+            const svc = TestBed.inject(TbxMatBannerService);
+
+            svc.show({
+                type: TbxMatSeverityLevel.Success,
+                message: 'Test',
+                animation: TbxMatBannerAnimation.Slide,
+            });
+
+            const config = overlaySpy.create.mock.calls[0][0];
+            expect(config.panelClass).toContain('tbx-mat-banner-anim-slide');
+            expect(config.panelClass).not.toContain('tbx-mat-banner-anim-fade');
         });
     });
 

--- a/src/services/banner.service.ts
+++ b/src/services/banner.service.ts
@@ -395,20 +395,30 @@ export class TbxMatBannerService {
             message: config.message,
             dismissByClose: () => {
                 if (this.activeOverlayRef !== overlayRef) return;
-                this.resolveAndCleanup({
+                const result: TbxMatBannerResult = {
                     dismissReason: TbxMatBannerDismissReason.Close,
                     actionsGroupValues: this.activeComponentRef?.collectActionsGroupValues() ?? {},
-                });
-                this.showNext();
+                };
+                if (effectiveAnimation === TbxMatBannerAnimation.Slide || effectiveAnimation === TbxMatBannerAnimation.Fade) {
+                    this.animateExit(overlayRef, effectiveAnimation, result);
+                } else {
+                    this.resolveAndCleanup(result);
+                    this.showNext();
+                }
             },
             dismissByAction: (actionKey: string) => {
                 if (this.activeOverlayRef !== overlayRef) return;
-                this.resolveAndCleanup({
+                const actionResult: TbxMatBannerResult = {
                     dismissReason: TbxMatBannerDismissReason.Action,
                     actionKey,
                     actionsGroupValues: this.activeComponentRef?.collectActionsGroupValues() ?? {},
-                });
-                this.showNext();
+                };
+                if (effectiveAnimation === TbxMatBannerAnimation.Slide || effectiveAnimation === TbxMatBannerAnimation.Fade) {
+                    this.animateExit(overlayRef, effectiveAnimation, actionResult);
+                } else {
+                    this.resolveAndCleanup(actionResult);
+                    this.showNext();
+                }
             },
             duration,
             showSeverityIcon: config.showSeverityIcon ?? true,
@@ -431,11 +441,16 @@ export class TbxMatBannerService {
         if (duration > 0) {
             this.durationTimeout = setTimeout(() => {
                 this.durationTimeout = null;
-                this.resolveAndCleanup({
+                const timeoutResult: TbxMatBannerResult = {
                     dismissReason: TbxMatBannerDismissReason.Timeout,
                     actionsGroupValues: this.activeComponentRef?.collectActionsGroupValues() ?? {},
-                });
-                this.showNext();
+                };
+                if (effectiveAnimation === TbxMatBannerAnimation.Slide || effectiveAnimation === TbxMatBannerAnimation.Fade) {
+                    this.animateExit(overlayRef, effectiveAnimation, timeoutResult);
+                } else {
+                    this.resolveAndCleanup(timeoutResult);
+                    this.showNext();
+                }
             }, duration);
         }
     }
@@ -463,6 +478,47 @@ export class TbxMatBannerService {
 
         this.activeComponentRef = null;
         this._isActive.set(false);
+    }
+
+    /**
+     * Run the exit animation, then resolve the result and clean up.
+     * Nulls activeOverlayRef immediately so the ref-comparison guard
+     * prevents re-entrant dismiss calls while the animation runs.
+     */
+    private animateExit(overlayRef: OverlayRef, animation: TbxMatBannerAnimation, result: TbxMatBannerResult): void {
+        const element = overlayRef.overlayElement;
+        element.classList.add(`tbx-mat-banner-anim-${animation}-out`);
+
+        // Null ref immediately so stale dismiss calls bail via the guard
+        this.activeOverlayRef = null;
+
+        // Resolve promise immediately — consumer shouldn't wait for the animation
+        if (!this.activeResultResolved && this.activeResultResolver) {
+            this.activeResultResolver(result);
+            this.activeResultResolver = null;
+            this.activeResultResolved = true;
+        }
+
+        if (this.durationTimeout) {
+            clearTimeout(this.durationTimeout);
+            this.durationTimeout = null;
+        }
+
+        let disposed = false;
+        const finalize = () => {
+            if (disposed) return;
+            disposed = true;
+            overlayRef.dispose();
+            this.activeComponentRef = null;
+            this._isActive.set(false);
+            this.showNext();
+        };
+
+        element.addEventListener('animationend', finalize, { once: true });
+
+        // Safety ceiling — force disposal if animationend never fires
+        // (prefers-reduced-motion, browser quirks, detached element)
+        setTimeout(finalize, 1000);
     }
 
     /** Clean up active overlay on service destroy. */

--- a/src/services/banner.service.ts
+++ b/src/services/banner.service.ts
@@ -8,6 +8,7 @@ import { type TbxMatBannerConfig } from '../models/banner-config.model';
 import { type TbxMatBannerRef } from '../models/banner-ref.model';
 import { type TbxMatBannerResult } from '../models/banner-result.model';
 import { type BannerDataDto } from '../models/banner-data-dto.model';
+import { TbxMatBannerAnimation } from '../enums/banner-animation.enum';
 import { TbxMatBannerDismissReason } from '../enums/banner-dismiss-reason.enum';
 import { TBX_MAT_BANNER_PROVIDER_CONFIG } from '../tokens/banner-provider-config.token';
 import { TBX_MAT_BANNER_DATA } from '../tokens/banner-data.token';
@@ -363,6 +364,11 @@ export class TbxMatBannerService {
         const consumerPanelClass = config.panelClass;
         const positionClass = config.verticalPosition === 'bottom' ? 'tbx-mat-banner-position-bottom' : 'tbx-mat-banner-position-top';
         const mergedPanelClass: string[] = ['tbx-mat-banner-overlay-panel', positionClass, PANEL_CLASS_MAP[config.type], ...(Array.isArray(consumerPanelClass) ? consumerPanelClass : consumerPanelClass ? [consumerPanelClass] : [])];
+
+        const effectiveAnimation = config.animation ?? this.providerConfig.defaultAnimation;
+        if (effectiveAnimation === TbxMatBannerAnimation.Slide || effectiveAnimation === TbxMatBannerAnimation.Fade) {
+            mergedPanelClass.push(`tbx-mat-banner-anim-${effectiveAnimation}`);
+        }
 
         // Create overlay
         const positionStrategy = this.overlay.position().global().centerHorizontally();

--- a/src/services/banner.service.ts
+++ b/src/services/banner.service.ts
@@ -16,24 +16,6 @@ import { TbxMatBannerCloseFontIconService } from './banner-close-font-icon.servi
 import { BANNER_DEFAULT_DURATION_MS } from '../constants/banner.constants';
 
 /**
- * Panel CSS class mapping for each banner severity level.
- *
- * These classes are applied to the CDK overlay panel via
- * `OverlayConfig.panelClass`. The corresponding styles are defined
- * in src/styles/_tbx-mat-banners.scss — consumers must import this
- * partial into their global stylesheet (overlay panels render
- * outside component scope).
- */
-const PANEL_CLASS_MAP: Readonly<Record<TbxMatSeverityLevel, string>> = {
-    [TbxMatSeverityLevel.Default]: 'tbx-mat-banner-panel-default',
-    [TbxMatSeverityLevel.Success]: 'tbx-mat-banner-panel-success',
-    [TbxMatSeverityLevel.Error]: 'tbx-mat-banner-panel-error',
-    [TbxMatSeverityLevel.Warning]: 'tbx-mat-banner-panel-warning',
-    [TbxMatSeverityLevel.Information]: 'tbx-mat-banner-panel-information',
-    [TbxMatSeverityLevel.Help]: 'tbx-mat-banner-panel-help',
-};
-
-/**
  * Internal queue entry. Pairs a banner config with the promise
  * resolver needed to fulfill the TbxMatBannerRef returned to
  * the consumer.
@@ -363,11 +345,18 @@ export class TbxMatBannerService {
         // Build panel classes
         const consumerPanelClass = config.panelClass;
         const positionClass = config.verticalPosition === 'bottom' ? 'tbx-mat-banner-position-bottom' : 'tbx-mat-banner-position-top';
-        const mergedPanelClass: string[] = ['tbx-mat-banner-overlay-panel', positionClass, PANEL_CLASS_MAP[config.type], ...(Array.isArray(consumerPanelClass) ? consumerPanelClass : consumerPanelClass ? [consumerPanelClass] : [])];
+        const mergedPanelClass: string[] = ['tbx-mat-banner-overlay-panel', positionClass, ...(Array.isArray(consumerPanelClass) ? consumerPanelClass : consumerPanelClass ? [consumerPanelClass] : [])];
 
         const effectiveAnimation = config.animation ?? this.providerConfig.defaultAnimation;
-        if (effectiveAnimation === TbxMatBannerAnimation.Slide || effectiveAnimation === TbxMatBannerAnimation.Fade) {
-            mergedPanelClass.push(`tbx-mat-banner-anim-${effectiveAnimation}`);
+        const position = config.verticalPosition === 'bottom' ? 'bottom' : 'top';
+        let enterAnimationClass = '';
+        let leaveAnimationClass = '';
+        if (effectiveAnimation === TbxMatBannerAnimation.Slide) {
+            enterAnimationClass = `tbx-mat-banner-slide-in-${position}`;
+            leaveAnimationClass = `tbx-mat-banner-slide-out-${position}`;
+        } else if (effectiveAnimation === TbxMatBannerAnimation.Fade) {
+            enterAnimationClass = 'tbx-mat-banner-fade-in';
+            leaveAnimationClass = 'tbx-mat-banner-fade-out';
         }
 
         // Create overlay
@@ -389,42 +378,38 @@ export class TbxMatBannerService {
         const overlayRef = this.overlay.create(overlayConfig);
         this.activeOverlayRef = overlayRef;
 
+        // When animation is active, showNext is deferred to the leave animation callback
+        const hasAnimation = enterAnimationClass !== '';
+
         // Build DTO
         const data: BannerDataDto = {
             type: config.type,
             message: config.message,
             dismissByClose: () => {
                 if (this.activeOverlayRef !== overlayRef) return;
-                const result: TbxMatBannerResult = {
+                this.resolveAndCleanup({
                     dismissReason: TbxMatBannerDismissReason.Close,
                     actionsGroupValues: this.activeComponentRef?.collectActionsGroupValues() ?? {},
-                };
-                if (effectiveAnimation === TbxMatBannerAnimation.Slide || effectiveAnimation === TbxMatBannerAnimation.Fade) {
-                    this.animateExit(overlayRef, effectiveAnimation, result);
-                } else {
-                    this.resolveAndCleanup(result);
-                    this.showNext();
-                }
+                });
+                if (!hasAnimation) this.showNext();
             },
             dismissByAction: (actionKey: string) => {
                 if (this.activeOverlayRef !== overlayRef) return;
-                const actionResult: TbxMatBannerResult = {
+                this.resolveAndCleanup({
                     dismissReason: TbxMatBannerDismissReason.Action,
                     actionKey,
                     actionsGroupValues: this.activeComponentRef?.collectActionsGroupValues() ?? {},
-                };
-                if (effectiveAnimation === TbxMatBannerAnimation.Slide || effectiveAnimation === TbxMatBannerAnimation.Fade) {
-                    this.animateExit(overlayRef, effectiveAnimation, actionResult);
-                } else {
-                    this.resolveAndCleanup(actionResult);
-                    this.showNext();
-                }
+                });
+                if (!hasAnimation) this.showNext();
             },
             duration,
             showSeverityIcon: config.showSeverityIcon ?? true,
             showCloseButton: config.showCloseButton ?? true,
             closeIconResolverService: this.providerConfig.closeIconResolverService ?? this.defaultCloseIconService,
             actionsGroup: config.actionsGroup ?? [],
+            enterAnimationClass,
+            leaveAnimationClass,
+            onLeaveAnimationDone: hasAnimation ? () => this.showNext() : null,
         };
 
         // Create component portal with injected data
@@ -441,16 +426,11 @@ export class TbxMatBannerService {
         if (duration > 0) {
             this.durationTimeout = setTimeout(() => {
                 this.durationTimeout = null;
-                const timeoutResult: TbxMatBannerResult = {
+                this.resolveAndCleanup({
                     dismissReason: TbxMatBannerDismissReason.Timeout,
                     actionsGroupValues: this.activeComponentRef?.collectActionsGroupValues() ?? {},
-                };
-                if (effectiveAnimation === TbxMatBannerAnimation.Slide || effectiveAnimation === TbxMatBannerAnimation.Fade) {
-                    this.animateExit(overlayRef, effectiveAnimation, timeoutResult);
-                } else {
-                    this.resolveAndCleanup(timeoutResult);
-                    this.showNext();
-                }
+                });
+                if (!hasAnimation) this.showNext();
             }, duration);
         }
     }
@@ -478,47 +458,6 @@ export class TbxMatBannerService {
 
         this.activeComponentRef = null;
         this._isActive.set(false);
-    }
-
-    /**
-     * Run the exit animation, then resolve the result and clean up.
-     * Nulls activeOverlayRef immediately so the ref-comparison guard
-     * prevents re-entrant dismiss calls while the animation runs.
-     */
-    private animateExit(overlayRef: OverlayRef, animation: TbxMatBannerAnimation, result: TbxMatBannerResult): void {
-        const element = overlayRef.overlayElement;
-        element.classList.add(`tbx-mat-banner-anim-${animation}-out`);
-
-        // Null ref immediately so stale dismiss calls bail via the guard
-        this.activeOverlayRef = null;
-
-        // Resolve promise immediately — consumer shouldn't wait for the animation
-        if (!this.activeResultResolved && this.activeResultResolver) {
-            this.activeResultResolver(result);
-            this.activeResultResolver = null;
-            this.activeResultResolved = true;
-        }
-
-        if (this.durationTimeout) {
-            clearTimeout(this.durationTimeout);
-            this.durationTimeout = null;
-        }
-
-        let disposed = false;
-        const finalize = () => {
-            if (disposed) return;
-            disposed = true;
-            overlayRef.dispose();
-            this.activeComponentRef = null;
-            this._isActive.set(false);
-            this.showNext();
-        };
-
-        element.addEventListener('animationend', finalize, { once: true });
-
-        // Safety ceiling — force disposal if animationend never fires
-        // (prefers-reduced-motion, browser quirks, detached element)
-        setTimeout(finalize, 1000);
     }
 
     /** Clean up active overlay on service destroy. */

--- a/src/styles/_tbx-mat-banners.scss
+++ b/src/styles/_tbx-mat-banners.scss
@@ -78,6 +78,108 @@ html {
     }
 }
 
+/* ━━━ Overlay Animations ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ *
+ * CSS keyframe animations for overlay banner enter and exit.
+ * Applied via panelClass by TbxMatBannerService when config.animation
+ * is set to Slide or Fade. Exit classes (-out) are added by the
+ * service's animateExit() method on dismiss.
+ *
+ * Consumer-tunable via:
+ * --tbx-mat-banner-anim-duration  (default: 300ms)
+ * --tbx-mat-banner-anim-easing    (default: cubic-bezier(0.25, 0.8, 0.25, 1))
+ * ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ */
+
+/* ── Enter — slide ── */
+
+.tbx-mat-banner-anim-slide.tbx-mat-banner-position-top {
+    animation: tbx-mat-banner-slide-in-top
+        var(--tbx-mat-banner-anim-duration, 300ms)
+        var(--tbx-mat-banner-anim-easing, cubic-bezier(0.25, 0.8, 0.25, 1));
+}
+
+.tbx-mat-banner-anim-slide.tbx-mat-banner-position-bottom {
+    animation: tbx-mat-banner-slide-in-bottom
+        var(--tbx-mat-banner-anim-duration, 300ms)
+        var(--tbx-mat-banner-anim-easing, cubic-bezier(0.25, 0.8, 0.25, 1));
+}
+
+/* ── Exit — slide ── */
+
+.tbx-mat-banner-anim-slide-out.tbx-mat-banner-position-top {
+    animation: tbx-mat-banner-slide-out-top
+        var(--tbx-mat-banner-anim-duration, 300ms)
+        var(--tbx-mat-banner-anim-easing, cubic-bezier(0.25, 0.8, 0.25, 1))
+        forwards;
+}
+
+.tbx-mat-banner-anim-slide-out.tbx-mat-banner-position-bottom {
+    animation: tbx-mat-banner-slide-out-bottom
+        var(--tbx-mat-banner-anim-duration, 300ms)
+        var(--tbx-mat-banner-anim-easing, cubic-bezier(0.25, 0.8, 0.25, 1))
+        forwards;
+}
+
+/* ── Enter — fade ── */
+
+.tbx-mat-banner-anim-fade {
+    animation: tbx-mat-banner-fade-in
+        var(--tbx-mat-banner-anim-duration, 300ms)
+        var(--tbx-mat-banner-anim-easing, cubic-bezier(0.25, 0.8, 0.25, 1));
+}
+
+/* ── Exit — fade ── */
+
+.tbx-mat-banner-anim-fade-out {
+    animation: tbx-mat-banner-fade-out
+        var(--tbx-mat-banner-anim-duration, 300ms)
+        var(--tbx-mat-banner-anim-easing, cubic-bezier(0.25, 0.8, 0.25, 1))
+        forwards;
+}
+
+/* ── Keyframes ── */
+
+@keyframes tbx-mat-banner-slide-in-top {
+    from { transform: translateY(-100%); }
+    to   { transform: translateY(0); }
+}
+
+@keyframes tbx-mat-banner-slide-out-top {
+    from { transform: translateY(0); }
+    to   { transform: translateY(-100%); }
+}
+
+@keyframes tbx-mat-banner-slide-in-bottom {
+    from { transform: translateY(100%); }
+    to   { transform: translateY(0); }
+}
+
+@keyframes tbx-mat-banner-slide-out-bottom {
+    from { transform: translateY(0); }
+    to   { transform: translateY(100%); }
+}
+
+@keyframes tbx-mat-banner-fade-in {
+    from { opacity: 0; }
+    to   { opacity: 1; }
+}
+
+@keyframes tbx-mat-banner-fade-out {
+    from { opacity: 1; }
+    to   { opacity: 0; }
+}
+
+/* ── Reduced motion ── */
+
+@media (prefers-reduced-motion: reduce) {
+    .tbx-mat-banner-anim-slide,
+    .tbx-mat-banner-anim-fade,
+    .tbx-mat-banner-anim-slide-out,
+    .tbx-mat-banner-anim-fade-out {
+        animation: none !important;
+    }
+}
+
 /* ━━━ Panel Styles ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  *
  * Applied to the CDK overlay panel via panelClass.

--- a/src/styles/_tbx-mat-banners.scss
+++ b/src/styles/_tbx-mat-banners.scss
@@ -70,112 +70,129 @@ html {
     font-size: var(--mat-sys-body-large-size, 0.875rem);
     line-height: var(--mat-sys-body-large-line-height, 1.25rem);
     letter-spacing: var(--mat-sys-body-large-tracking, 0.0178571429em);
-    box-shadow: var(--tbx-mat-banner-overlay-shadow, 0 2px 4px -1px rgba(0, 0, 0, 0.2), 0 4px 5px 0 rgba(0, 0, 0, 0.14), 0 1px 10px 0 rgba(0, 0, 0, 0.12));
+
+    /* Shadow set as a variable so the component host inherits it.
+     * The host renders the shadow (not the pane) so it animates
+     * with the enter/leave animation. */
+    --tbx-mat-banner-panel-shadow: var(--tbx-mat-banner-overlay-shadow, 0 2px 4px -1px rgba(0, 0, 0, 0.2), 0 4px 5px 0 rgba(0, 0, 0, 0.14), 0 1px 10px 0 rgba(0, 0, 0, 0.12));
 
     /* Bottom-positioned banners cast shadow upward */
     &.tbx-mat-banner-position-bottom {
-        box-shadow: var(--tbx-mat-banner-overlay-shadow, 0 -2px 4px -1px rgba(0, 0, 0, 0.2), 0 -4px 5px 0 rgba(0, 0, 0, 0.14), 0 -1px 10px 0 rgba(0, 0, 0, 0.12));
+        --tbx-mat-banner-panel-shadow: var(--tbx-mat-banner-overlay-shadow, 0 -2px 4px -1px rgba(0, 0, 0, 0.2), 0 -4px 5px 0 rgba(0, 0, 0, 0.14), 0 -1px 10px 0 rgba(0, 0, 0, 0.12));
     }
 }
 
 /* ━━━ Overlay Animations ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  *
  * CSS keyframe animations for overlay banner enter and exit.
- * Applied via panelClass by TbxMatBannerService when config.animation
- * is set to Slide or Fade. Exit classes (-out) are added by the
- * service's animateExit() method on dismiss.
+ * Applied to the TbxMatBannerComponent host element via Angular's
+ * native animate.enter / animate.leave directives. Class names are
+ * computed by TbxMatBannerService and passed through the DTO.
  *
  * Consumer-tunable via:
- * --tbx-mat-banner-anim-duration  (default: 300ms)
- * --tbx-mat-banner-anim-easing    (default: cubic-bezier(0.25, 0.8, 0.25, 1))
+ * --tbx-mat-banner-anim-enter-duration  (default: 300ms)
+ * --tbx-mat-banner-anim-enter-easing    (default: cubic-bezier(0.25, 0.8, 0.25, 1) — deceleration)
+ * --tbx-mat-banner-anim-exit-duration   (default: 250ms)
+ * --tbx-mat-banner-anim-exit-easing     (default: cubic-bezier(0.4, 0, 0.6, 1) — standard)
  * ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ */
 
 /* ── Enter — slide ── */
 
-.tbx-mat-banner-anim-slide.tbx-mat-banner-position-top {
-    animation: tbx-mat-banner-slide-in-top
-        var(--tbx-mat-banner-anim-duration, 300ms)
-        var(--tbx-mat-banner-anim-easing, cubic-bezier(0.25, 0.8, 0.25, 1));
+.tbx-mat-banner-slide-in-top {
+    animation: tbx-mat-banner-slide-in-top var(--tbx-mat-banner-anim-enter-duration, 300ms) var(--tbx-mat-banner-anim-enter-easing, cubic-bezier(0.25, 0.8, 0.25, 1));
 }
 
-.tbx-mat-banner-anim-slide.tbx-mat-banner-position-bottom {
-    animation: tbx-mat-banner-slide-in-bottom
-        var(--tbx-mat-banner-anim-duration, 300ms)
-        var(--tbx-mat-banner-anim-easing, cubic-bezier(0.25, 0.8, 0.25, 1));
+.tbx-mat-banner-slide-in-bottom {
+    animation: tbx-mat-banner-slide-in-bottom var(--tbx-mat-banner-anim-enter-duration, 300ms) var(--tbx-mat-banner-anim-enter-easing, cubic-bezier(0.25, 0.8, 0.25, 1));
 }
 
 /* ── Exit — slide ── */
 
-.tbx-mat-banner-anim-slide-out.tbx-mat-banner-position-top {
-    animation: tbx-mat-banner-slide-out-top
-        var(--tbx-mat-banner-anim-duration, 300ms)
-        var(--tbx-mat-banner-anim-easing, cubic-bezier(0.25, 0.8, 0.25, 1))
-        forwards;
+.tbx-mat-banner-slide-out-top {
+    animation: tbx-mat-banner-slide-out-top var(--tbx-mat-banner-anim-exit-duration, 250ms) var(--tbx-mat-banner-anim-exit-easing, cubic-bezier(0.4, 0, 0.6, 1)) forwards;
 }
 
-.tbx-mat-banner-anim-slide-out.tbx-mat-banner-position-bottom {
-    animation: tbx-mat-banner-slide-out-bottom
-        var(--tbx-mat-banner-anim-duration, 300ms)
-        var(--tbx-mat-banner-anim-easing, cubic-bezier(0.25, 0.8, 0.25, 1))
-        forwards;
+.tbx-mat-banner-slide-out-bottom {
+    animation: tbx-mat-banner-slide-out-bottom var(--tbx-mat-banner-anim-exit-duration, 250ms) var(--tbx-mat-banner-anim-exit-easing, cubic-bezier(0.4, 0, 0.6, 1)) forwards;
 }
 
 /* ── Enter — fade ── */
 
-.tbx-mat-banner-anim-fade {
-    animation: tbx-mat-banner-fade-in
-        var(--tbx-mat-banner-anim-duration, 300ms)
-        var(--tbx-mat-banner-anim-easing, cubic-bezier(0.25, 0.8, 0.25, 1));
+.tbx-mat-banner-fade-in {
+    animation: tbx-mat-banner-fade-in var(--tbx-mat-banner-anim-enter-duration, 300ms) var(--tbx-mat-banner-anim-enter-easing, cubic-bezier(0.25, 0.8, 0.25, 1));
 }
 
 /* ── Exit — fade ── */
 
-.tbx-mat-banner-anim-fade-out {
-    animation: tbx-mat-banner-fade-out
-        var(--tbx-mat-banner-anim-duration, 300ms)
-        var(--tbx-mat-banner-anim-easing, cubic-bezier(0.25, 0.8, 0.25, 1))
-        forwards;
+.tbx-mat-banner-fade-out {
+    animation: tbx-mat-banner-fade-out var(--tbx-mat-banner-anim-exit-duration, 250ms) var(--tbx-mat-banner-anim-exit-easing, cubic-bezier(0.4, 0, 0.6, 1)) forwards;
 }
 
 /* ── Keyframes ── */
 
 @keyframes tbx-mat-banner-slide-in-top {
-    from { transform: translateY(-100%); }
-    to   { transform: translateY(0); }
+    from {
+        transform: translateY(-100%);
+    }
+    to {
+        transform: translateY(0);
+    }
 }
 
 @keyframes tbx-mat-banner-slide-out-top {
-    from { transform: translateY(0); }
-    to   { transform: translateY(-100%); }
+    from {
+        transform: translateY(0);
+    }
+    to {
+        transform: translateY(-100%);
+    }
 }
 
 @keyframes tbx-mat-banner-slide-in-bottom {
-    from { transform: translateY(100%); }
-    to   { transform: translateY(0); }
+    from {
+        transform: translateY(100%);
+    }
+    to {
+        transform: translateY(0);
+    }
 }
 
 @keyframes tbx-mat-banner-slide-out-bottom {
-    from { transform: translateY(0); }
-    to   { transform: translateY(100%); }
+    from {
+        transform: translateY(0);
+    }
+    to {
+        transform: translateY(100%);
+    }
 }
 
 @keyframes tbx-mat-banner-fade-in {
-    from { opacity: 0; }
-    to   { opacity: 1; }
+    from {
+        opacity: 0;
+    }
+    to {
+        opacity: 1;
+    }
 }
 
 @keyframes tbx-mat-banner-fade-out {
-    from { opacity: 1; }
-    to   { opacity: 0; }
+    from {
+        opacity: 1;
+    }
+    to {
+        opacity: 0;
+    }
 }
 
 /* ── Reduced motion ── */
 
 @media (prefers-reduced-motion: reduce) {
-    .tbx-mat-banner-anim-slide,
-    .tbx-mat-banner-anim-fade,
-    .tbx-mat-banner-anim-slide-out,
-    .tbx-mat-banner-anim-fade-out {
+    .tbx-mat-banner-slide-in-top,
+    .tbx-mat-banner-slide-in-bottom,
+    .tbx-mat-banner-slide-out-top,
+    .tbx-mat-banner-slide-out-bottom,
+    .tbx-mat-banner-fade-in,
+    .tbx-mat-banner-fade-out {
         animation: none !important;
     }
 }


### PR DESCRIPTION
## Summary
- Introduce `TbxMatBannerAnimation` enum (`None`, `Slide`, `Fade`) with per-banner `config.animation` and app-wide `providerConfig.defaultAnimation` support. Per-call config wins over provider default; when both are omitted, banners appear/disappear instantly (current behavior preserved).
- Animations use Angular's native `animate.enter` / `animate.leave` host bindings (Angular 20.2+) with CSS keyframes — no `@angular/animations` dependency. Angular handles DOM removal timing and the leave animation lifecycle.
- Severity panel class and box-shadow moved from the CDK overlay pane to the component host so the entire banner (background, shadow, content) animates as a single unit.
- Sequential queued transitions: `showNext()` is deferred via an `onLeaveAnimationDone` DTO callback fired by the `(animate.leave)` host event, so the next banner enters only after the current one finishes leaving.
- Separate enter/exit CSS custom properties for consumer tuning:
  - `--tbx-mat-banner-anim-enter-duration` (default 300ms)
  - `--tbx-mat-banner-anim-enter-easing` (default deceleration curve)
  - `--tbx-mat-banner-anim-exit-duration` (default 250ms)
  - `--tbx-mat-banner-anim-exit-easing` (default standard curve)
- `prefers-reduced-motion: reduce` media query disables all banner animations.
- Animation and verticalPosition Storybook controls added to all four overlay story harnesses.

Closes #38

## Test plan
- [ ] `npm run lint && npm run typecheck && npm test` — 121/121 tests pass
- [ ] `npm run test:coverage` — all per-file thresholds met
- [ ] Storybook: open each overlay story (Overlay, Actions Group, Font Icon Variants, SVG Icons), set animation to `slide` and `fade`, fire banners and verify smooth enter/exit. Queue 6 banners and verify sequential transitions. Switch to `none` and verify instant show/hide. Test both top and bottom positions.
- [ ] Storybook: open Banners/Inline stories and verify no animation controls appear and inline banners behave as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)