### PR TITLE
docs: address post-0.8.0 AI friendliness audit findings (#56)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ This is a `@teqbench` [npm ↗](https://www.npmjs.com) package built with [TypeS
 
 ## Tech Stack
 
-- **Language:** [TypeScript ↗](https://www.typescriptlang.org) 5.9+ (strict mode, ES2022 target, bundler module resolution)
+- **Language:** [TypeScript ↗](https://www.typescriptlang.org) (strict mode, ES2022 target, bundler module resolution)
 - **Testing:** [Vitest ↗](https://vitest.dev) (globals enabled)
 - **Linting:** [ESLint ↗](https://eslint.org) flat config with [typescript-eslint ↗](https://typescript-eslint.io)
 - **Formatting:** [Prettier ↗](https://prettier.io) (enforced via pre-commit hook and CI)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 ### Node.js
 
-Install the version specified in `.nvmrc` ([Node.js ↗](https://nodejs.org) 24+). If you use [nvm ↗](https://github.com/nvm-sh/nvm):
+Install the version specified in `.nvmrc` ([Node.js ↗](https://nodejs.org)). If you use [nvm ↗](https://github.com/nvm-sh/nvm):
 
 ```bash
 nvm install
@@ -21,7 +21,7 @@ This package depends on `@teqbench` scoped packages hosted on [GitHub Packages �
     export GITHUB_TOKEN=ghp_yourTokenHere
     ```
 3. Add the auth line to your **user-level** `~/.npmrc` (not the repo `.npmrc`):
-    ```
+    ```ini
     //npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}
     ```
 4. Open a new terminal (or `source ~/.zshrc`) and verify: `npm ci`
@@ -34,7 +34,7 @@ If this package depends on other `@teqbench` packages, each package in the entir
 
 ## Tech Stack
 
-- **Language:** [TypeScript ↗](https://www.typescriptlang.org) 5.9+
+- **Language:** [TypeScript ↗](https://www.typescriptlang.org)
 - **Testing:** [Vitest ↗](https://vitest.dev)
 - **Linting:** [ESLint ↗](https://eslint.org) (Flat Config)
 - **Formatting:** [Prettier ↗](https://prettier.io) (enforced via pre-commit hook and CI)

--- a/README.md
+++ b/README.md
@@ -315,19 +315,19 @@ Effective only when `animation` is `Slide` or `Fade`. Ignored when `None`.
 
 ### TbxMatBannerService
 
-| Method                          | Returns           | Description                                                            |
-| ------------------------------- | ----------------- | ---------------------------------------------------------------------- |
-| `success(message, config?)`     | `TbxMatBannerRef` | Show a success banner                                                  |
-| `error(message, config?)`       | `TbxMatBannerRef` | Show an error banner                                                   |
-| `warning(message, config?)`     | `TbxMatBannerRef` | Show a warning banner                                                  |
-| `information(message, config?)` | `TbxMatBannerRef` | Show an information banner                                             |
-| `help(message, config?)`        | `TbxMatBannerRef` | Show a help banner                                                     |
-| `default(message, config?)`     | `TbxMatBannerRef` | Show a default banner (no severity styling)                            |
-| `show(config)`                  | `TbxMatBannerRef` | Show a banner with full config                                         |
-| `dismiss()`                     | `void`            | Dismiss current (resolves with ProgrammaticDismissCurrent)             |
-| `dismissAll()`                  | `void`            | Dismiss current and clear queue (resolves with ProgrammaticDismissAll) |
-| `isActive()`                    | `Signal<boolean>` | Whether a banner is visible                                            |
-| `pendingCount()`                | `Signal<number>`  | Count of queued banners                                                |
+| Method                          | Returns           | Description                                                                                                |
+| ------------------------------- | ----------------- | ---------------------------------------------------------------------------------------------------------- |
+| `success(message, config?)`     | `TbxMatBannerRef` | Show a success banner                                                                                      |
+| `error(message, config?)`       | `TbxMatBannerRef` | Show an error banner                                                                                       |
+| `warning(message, config?)`     | `TbxMatBannerRef` | Show a warning banner                                                                                      |
+| `information(message, config?)` | `TbxMatBannerRef` | Show an information banner                                                                                 |
+| `help(message, config?)`        | `TbxMatBannerRef` | Show a help banner                                                                                         |
+| `default(message, config?)`     | `TbxMatBannerRef` | Show a default banner (no severity styling)                                                                |
+| `show(config)`                  | `TbxMatBannerRef` | Show a banner with full config                                                                             |
+| `dismiss()`                     | `void`            | Dismiss the current banner; its `result` promise resolves with `ProgrammaticDismissCurrent`                |
+| `dismissAll()`                  | `void`            | Dismiss current and clear the queue; each banner's `result` promise resolves with `ProgrammaticDismissAll` |
+| `isActive()`                    | `Signal<boolean>` | Whether a banner is visible                                                                                |
+| `pendingCount()`                | `Signal<number>`  | Count of queued banners                                                                                    |
 
 ### TbxMatBannerRef
 

--- a/docs/reference/workflows/ci.md
+++ b/docs/reference/workflows/ci.md
@@ -74,7 +74,7 @@ The reusable workflow performs the following steps:
 
 Badges are rendered by [Shields.io ↗](https://shields.io/badges/endpoint-badge) endpoint badges. The URL format is:
 
-```
+```text
 https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/{GIST_OWNER}/{GIST_ID}/raw/{REPO_NAME}-{BRANCH}-{badge}.json
 ```
 

--- a/docs/reference/workflows/claude.md
+++ b/docs/reference/workflows/claude.md
@@ -74,7 +74,7 @@ Claude reads the `CLAUDE.md` file in the repo root for project-specific context.
 
 In any issue or PR comment:
 
-```
+```text
 @claude implement this feature based on the issue description
 @claude fix the bug described above
 @claude review this PR

--- a/docs/reference/workflows/dep-compat-check.md
+++ b/docs/reference/workflows/dep-compat-check.md
@@ -25,7 +25,7 @@ Tracks pinned dependencies that are waiting for a new version — for example, w
 
 ## Configuration
 
-The local `.yml` file passes `epic-issue-number` to the reusable workflow. This must be set to the tracking issue number during repository setup (see SETUP.md step 7).
+The local `.yml` file passes `epic-issue-number` to the reusable workflow. This must be set to the tracking issue number during repository setup.
 
 ---
 

--- a/src/components/banner.component.ts
+++ b/src/components/banner.component.ts
@@ -72,9 +72,8 @@ interface ResolvedIcon {
  * ```
  *
  * @example Inline mode:
- * ```typescript
- * // In template:
- * // <tbx-mat-banner [type]="severityLevel" [message]="'Hello'" (dismissed)="onDismiss($event)" />
+ * ```html
+ * <tbx-mat-banner [type]="severityLevel" [message]="'Hello'" (dismissed)="onDismiss($event)" />
  * ```
  *
  * @category Components
@@ -386,7 +385,15 @@ export class TbxMatBannerComponent implements OnInit {
         }
     }
 
-    /** Get the current value of a form control by key. */
+    /**
+     * Get the current value of a form control by key
+     *
+     * @param key - The control key to look up.
+     *
+     * @returns The current value of the control, or `undefined` if the key is not registered.
+     *
+     * @public
+     */
     getControlValue(key: string): unknown {
         return this.controlValues.get(key)?.();
     }
@@ -396,7 +403,13 @@ export class TbxMatBannerComponent implements OnInit {
         this.controlValues.get(key)?.set(value);
     }
 
-    /** Collect current values from all form controls. */
+    /**
+     * Collect current values from all form controls
+     *
+     * @returns A record keyed by control key with the current value of each form control.
+     *
+     * @public
+     */
     collectActionsGroupValues(): Record<string, unknown> {
         const values: Record<string, unknown> = {};
         for (const [key, sig] of this.controlValues) {
@@ -415,7 +428,15 @@ export class TbxMatBannerComponent implements OnInit {
         this.resolvedData().dismissByClose();
     }
 
-    /** Resolve an action button icon. */
+    /**
+     * Resolve an action button icon
+     *
+     * @param control - The action button control containing an optional icon key and resolver service.
+     *
+     * @returns The resolved icon, or `null` if no icon or resolver is configured.
+     *
+     * @public
+     */
     resolveActionIcon(control: {
         icon?: string;
         actionIconResolverService?: {

--- a/src/constants/banner.constants.ts
+++ b/src/constants/banner.constants.ts
@@ -10,19 +10,25 @@ import type { TbxMatBannerActionButtonAppearance } from '../types/banner-action-
  */
 
 /**
- * Default duration when no duration is specified (milliseconds).
+ * Default duration when no duration is specified (milliseconds)
  *
+ * @remarks
  * Used when {@link TbxMatBannerConfig.duration} is omitted.
  * Banners default to indefinite (0) — they remain visible until
  * dismissed by a user action or programmatically.
+ *
+ * @internal
  */
 export const BANNER_DEFAULT_DURATION_MS = 0;
 
 /**
- * Default action button appearance when not specified per-button.
+ * Default action button appearance when not specified per-button
  *
+ * @remarks
  * `'text'` is the lowest-emphasis button style, appropriate as a
  * default in contexts where the severity panel styling provides
  * the primary visual differentiation.
+ *
+ * @internal
  */
 export const BANNER_DEFAULT_ACTION_BUTTON_APPEARANCE: TbxMatBannerActionButtonAppearance = 'text';

--- a/src/models/banner-action-radio-group.model.ts
+++ b/src/models/banner-action-radio-group.model.ts
@@ -60,7 +60,7 @@ export interface TbxMatBannerRadioOption {
  *
  * @category Models
  * @displayName Banner Action Radio Group
- * @order 7
+ * @order 8
  * @since 1.0.0
  * @related TbxMatBannerRadioOption
  * @related TbxMatBannerConfig

--- a/src/models/banner-action-toggle-group.model.ts
+++ b/src/models/banner-action-toggle-group.model.ts
@@ -8,7 +8,7 @@
  *
  * @category Models
  * @displayName Banner Toggle Option
- * @order 8
+ * @order 9
  * @since 1.0.0
  *
  * @public
@@ -84,7 +84,7 @@ export interface TbxMatBannerToggleOption {
  *
  * @category Models
  * @displayName Banner Action Toggle Group
- * @order 8
+ * @order 10
  * @since 1.0.0
  * @related TbxMatBannerToggleOption
  * @related TbxMatBannerConfig

--- a/src/models/banner-config.model.ts
+++ b/src/models/banner-config.model.ts
@@ -42,6 +42,8 @@ import { type TbxMatBannerActionsGroupControl } from '../types/banner-actions-gr
  * ```
  *
  * @category Models
+ * @displayName Banner Config
+ * @order 1
  * @since 1.0.0
  * @related TbxMatBannerConfigArgs
  * @related TbxMatBannerService

--- a/src/models/banner-provider-config.model.ts
+++ b/src/models/banner-provider-config.model.ts
@@ -59,7 +59,7 @@ import { type TbxMatBannerAnimation } from '../enums/banner-animation.enum';
  *
  * @category Models
  * @displayName Banner Provider Config
- * @order 9
+ * @order 11
  * @since 1.0.0
  * @related TBX_MAT_BANNER_PROVIDER_CONFIG
  * @related TbxMatBannerSeverityFontIconService

--- a/src/services/banner-close-font-icon.service.ts
+++ b/src/services/banner-close-font-icon.service.ts
@@ -47,6 +47,7 @@ import { TbxMatFontIconService } from '@teqbench/tbx-mat-icons';
  *
  * @category Services
  * @displayName Close Font Icon Service
+ * @order 4
  * @since 1.0.0
  * @related TbxMatBannerProviderConfig
  * @related TbxMatBannerSeverityFontIconService

--- a/src/services/banner-severity-font-icon.service.ts
+++ b/src/services/banner-severity-font-icon.service.ts
@@ -55,6 +55,8 @@ import { TbxMatSeverityFontIconService, TbxMatSeverityLevel } from '@teqbench/tb
  * ```
  *
  * @category Services
+ * @displayName Severity Font Icon Service
+ * @order 2
  * @since 1.0.0
  * @related TBX_MAT_BANNER_PROVIDER_CONFIG
  * @related TbxMatBannerSeveritySvgIconService

--- a/src/services/banner-severity-svg-icon.service.ts
+++ b/src/services/banner-severity-svg-icon.service.ts
@@ -66,6 +66,8 @@ const SVG_HELP =
  * ```
  *
  * @category Services
+ * @displayName Severity SVG Icon Service
+ * @order 3
  * @since 1.0.0
  * @related TBX_MAT_BANNER_PROVIDER_CONFIG
  * @related TbxMatBannerSeverityFontIconService

--- a/src/services/banner.service.ts
+++ b/src/services/banner.service.ts
@@ -53,7 +53,8 @@ interface QueueEntry {
  * - `pendingCount()` — number of banners waiting in the queue
  *
  * @usage
- * Inject the service and call the convenience methods for each severity level.
+ * Inject the service and call the convenience methods for each severity level
+ * (`success()`, `error()`, `warning()`, `information()`, `help()`, `default()`).
  * Use `show()` when full control over configuration is needed. Use `dismiss()`
  * and `dismissAll()` to programmatically clear banners.
  *

--- a/src/types/banner-actions-group-control.type.ts
+++ b/src/types/banner-actions-group-control.type.ts
@@ -10,7 +10,7 @@ import { type TbxMatBannerActionToggleGroup } from '../models/banner-action-togg
  * @remarks
  * Each control in a banner's `actionsGroup` array must be one of these types.
  * The `type` property serves as the discriminant for type narrowing in
- * `@switch` blocks and conditional logic.
+ * `\@switch` blocks and conditional logic.
  *
  * Controls are rendered in the slot between the banner's message and close
  * button, in array order.


### PR DESCRIPTION
## Summary

- docs(tsdoc): add missing `@displayName`, `@order` tags and resolve duplicate `@order` values (#57)
- docs(tsdoc): add `@returns` tags, `@internal` release tags, and `default()` to service `@remarks` (#58)
- docs(readme): fix misleading `dismiss()`/`dismissAll()` descriptions in API table (#59)
- chore(docs): fix broken SETUP.md ref, code block languages, prose versions, and minor TSDoc fixes (#60)

Closes #56, closes #57, closes #58, closes #59, closes #60

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm test` passes (121 tests)
- [x] `npm run format:check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)