### PR TITLE
release: post-0.8.0 fixes and documentation

### DIFF
--- a/.github/workflows/dep-compat-check.yml
+++ b/.github/workflows/dep-compat-check.yml
@@ -1,7 +1,5 @@
 # Thin caller — delegates to the org-wide reusable Dep Compat Check workflow.
 # See: https://github.com/teqbench/.github/.github/workflows/dep-compat-check.yml
-#
-# UPDATE: Set epic-issue-number to the tracking issue number for this repo.
 
 name: Dependency Compatibility Check
 

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 
 # Node
 /node_modules
-npm-debug.log
+npm-debug.log*
 yarn-error.log
 
 # IDEs and editors

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ This is a `@teqbench` [npm ↗](https://www.npmjs.com) package built with [TypeS
 
 ## Tech Stack
 
-- **Language:** [TypeScript ↗](https://www.typescriptlang.org) 5.9+ (strict mode, ES2022 target, bundler module resolution)
+- **Language:** [TypeScript ↗](https://www.typescriptlang.org) (strict mode, ES2022 target, bundler module resolution)
 - **Testing:** [Vitest ↗](https://vitest.dev) (globals enabled)
 - **Linting:** [ESLint ↗](https://eslint.org) flat config with [typescript-eslint ↗](https://typescript-eslint.io)
 - **Formatting:** [Prettier ↗](https://prettier.io) (enforced via pre-commit hook and CI)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 ### Node.js
 
-Install the version specified in `.nvmrc` ([Node.js ↗](https://nodejs.org) 24+). If you use [nvm ↗](https://github.com/nvm-sh/nvm):
+Install the version specified in `.nvmrc` ([Node.js ↗](https://nodejs.org)). If you use [nvm ↗](https://github.com/nvm-sh/nvm):
 
 ```bash
 nvm install
@@ -21,7 +21,7 @@ This package depends on `@teqbench` scoped packages hosted on [GitHub Packages �
     export GITHUB_TOKEN=ghp_yourTokenHere
     ```
 3. Add the auth line to your **user-level** `~/.npmrc` (not the repo `.npmrc`):
-    ```
+    ```ini
     //npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}
     ```
 4. Open a new terminal (or `source ~/.zshrc`) and verify: `npm ci`
@@ -34,7 +34,7 @@ If this package depends on other `@teqbench` packages, each package in the entir
 
 ## Tech Stack
 
-- **Language:** [TypeScript ↗](https://www.typescriptlang.org) 5.9+
+- **Language:** [TypeScript ↗](https://www.typescriptlang.org)
 - **Testing:** [Vitest ↗](https://vitest.dev)
 - **Linting:** [ESLint ↗](https://eslint.org) (Flat Config)
 - **Formatting:** [Prettier ↗](https://prettier.io) (enforced via pre-commit hook and CI)

--- a/README.md
+++ b/README.md
@@ -394,14 +394,14 @@ Returned synchronously from all service methods.
 | [Angular CDK ↗](https://material.angular.dev/cdk)                                      | >=21.0.0 |
 | [Angular Material ↗](https://material.angular.dev)                                     | >=21.0.0 |
 | [@teqbench/tbx-mat-icons](https://github.com/teqbench/tbx-mat-icons)                   | >=4.0.0  |
-| [@teqbench/tbx-mat-severity-icons](https://github.com/teqbench/tbx-mat-severity-icons) | >=6.0.0  |
+| [@teqbench/tbx-mat-severity-icons](https://github.com/teqbench/tbx-mat-severity-icons) | >=7.0.0  |
 | [TypeScript ↗](https://www.typescriptlang.org)                                         | ~5.9.0   |
 | [Node.js ↗](https://nodejs.org)                                                        | >=24.0.0 |
 
 ## Feedback
 
-- [Report a bug](https://github.com/teqbench/tbx-mat-banners/issues/new?template=bug_report.md)
-- [Request a feature](https://github.com/teqbench/tbx-mat-banners/issues/new?template=feature_request.md)
+- [Report a bug ↗](https://github.com/teqbench/tbx-mat-banners/issues/new?template=bug_report.md)
+- [Request a feature ↗](https://github.com/teqbench/tbx-mat-banners/issues/new?template=feature_request.md)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -315,19 +315,19 @@ Effective only when `animation` is `Slide` or `Fade`. Ignored when `None`.
 
 ### TbxMatBannerService
 
-| Method                          | Returns           | Description                                                            |
-| ------------------------------- | ----------------- | ---------------------------------------------------------------------- |
-| `success(message, config?)`     | `TbxMatBannerRef` | Show a success banner                                                  |
-| `error(message, config?)`       | `TbxMatBannerRef` | Show an error banner                                                   |
-| `warning(message, config?)`     | `TbxMatBannerRef` | Show a warning banner                                                  |
-| `information(message, config?)` | `TbxMatBannerRef` | Show an information banner                                             |
-| `help(message, config?)`        | `TbxMatBannerRef` | Show a help banner                                                     |
-| `default(message, config?)`     | `TbxMatBannerRef` | Show a default banner (no severity styling)                            |
-| `show(config)`                  | `TbxMatBannerRef` | Show a banner with full config                                         |
-| `dismiss()`                     | `void`            | Dismiss current (resolves with ProgrammaticDismissCurrent)             |
-| `dismissAll()`                  | `void`            | Dismiss current and clear queue (resolves with ProgrammaticDismissAll) |
-| `isActive()`                    | `Signal<boolean>` | Whether a banner is visible                                            |
-| `pendingCount()`                | `Signal<number>`  | Count of queued banners                                                |
+| Method                          | Returns           | Description                                                                                                |
+| ------------------------------- | ----------------- | ---------------------------------------------------------------------------------------------------------- |
+| `success(message, config?)`     | `TbxMatBannerRef` | Show a success banner                                                                                      |
+| `error(message, config?)`       | `TbxMatBannerRef` | Show an error banner                                                                                       |
+| `warning(message, config?)`     | `TbxMatBannerRef` | Show a warning banner                                                                                      |
+| `information(message, config?)` | `TbxMatBannerRef` | Show an information banner                                                                                 |
+| `help(message, config?)`        | `TbxMatBannerRef` | Show a help banner                                                                                         |
+| `default(message, config?)`     | `TbxMatBannerRef` | Show a default banner (no severity styling)                                                                |
+| `show(config)`                  | `TbxMatBannerRef` | Show a banner with full config                                                                             |
+| `dismiss()`                     | `void`            | Dismiss the current banner; its `result` promise resolves with `ProgrammaticDismissCurrent`                |
+| `dismissAll()`                  | `void`            | Dismiss current and clear the queue; each banner's `result` promise resolves with `ProgrammaticDismissAll` |
+| `isActive()`                    | `Signal<boolean>` | Whether a banner is visible                                                                                |
+| `pendingCount()`                | `Signal<number>`  | Count of queued banners                                                                                    |
 
 ### TbxMatBannerRef
 

--- a/README.md
+++ b/README.md
@@ -77,10 +77,33 @@ if (result.actionKey === 'update') {
 }
 ```
 
+### Overlay — with animation
+
+```typescript
+import { TbxMatBannerAnimation } from '@teqbench/tbx-mat-banners';
+
+void this.banner.success('Item saved.', { animation: TbxMatBannerAnimation.Slide });
+void this.banner.error('Connection lost.', { animation: TbxMatBannerAnimation.Fade });
+```
+
+Animation is optional and defaults to `None` (instant show/hide). Set an app-wide default via the provider config:
+
+```typescript
+{
+    provide: TBX_MAT_BANNER_PROVIDER_CONFIG,
+    useFactory: () => ({
+        severityIconResolverService: new TbxMatBannerSeverityFontIconService(),
+        defaultAnimation: TbxMatBannerAnimation.Slide,
+    }),
+},
+```
+
+Animations are automatically disabled when the user has `prefers-reduced-motion: reduce` set.
+
 ### Overlay — full control via show()
 
 ```typescript
-import { TbxMatSeverityLevel } from '@teqbench/tbx-mat-banners';
+import { TbxMatSeverityLevel, TbxMatBannerAnimation } from '@teqbench/tbx-mat-banners';
 
 this.banner.show({
     type: TbxMatSeverityLevel.Warning,
@@ -90,21 +113,26 @@ this.banner.show({
         { type: 'button', key: 'save', label: 'Save', appearance: 'filled' },
     ],
     verticalPosition: 'top',
+    animation: TbxMatBannerAnimation.Slide,
 });
 ```
 
 ### Inline
 
-Place the component directly in your template. No service needed.
+Place the component directly in your template. No service needed. The component uses [Angular signal inputs ↗](https://angular.dev/guide/signals/inputs) — template binding syntax is unchanged.
 
 ```html
 <tbx-mat-banner
     [type]="severityLevel"
     message="This is an inline banner."
+    [showSeverityIcon]="true"
+    [showCloseButton]="true"
     [actionsGroup]="controls"
     (dismissed)="onDismiss($event)"
 />
 ```
+
+Available inputs: `type`, `message`, `duration`, `showSeverityIcon`, `showCloseButton`, `actionsGroup`. All are optional except `type`. The `(dismissed)` output emits a `TbxMatBannerResult` on dismiss. Animations are overlay-only — inline banners do not animate.
 
 ### Queue state (reactive signals)
 
@@ -180,19 +208,31 @@ Banner appearance is customizable via CSS custom properties. Set them globally o
 
 #### Layout
 
-| Property                           | Default       | Description                           |
-| ---------------------------------- | ------------- | ------------------------------------- |
-| `--tbx-mat-banner-padding`         | `0.5rem 1rem` | Host element padding                  |
-| `--tbx-mat-banner-font-size`       | `inherit`     | Message text size                     |
-| `--tbx-mat-banner-icon-size`       | `1.5rem`      | Severity icon size                    |
-| `--tbx-mat-banner-label-gap`       | `1rem`        | Gap between icon and message          |
-| `--tbx-mat-banner-actions-gap`     | `0.5rem`      | Gap between controls in actions group |
-| `--tbx-mat-banner-actions-padding` | `1rem`        | Padding before actions area           |
-| `--tbx-mat-banner-close-gap`       | `0.5rem`      | Gap between actions and close button  |
-| `--tbx-mat-banner-controls-gap`    | `0.75rem`     | Gap between input controls            |
-| `--tbx-mat-banner-buttons-gap`     | `0.5rem`      | Gap between action buttons            |
-| `--tbx-mat-banner-actions-row-gap` | `0.5rem`      | Gap between rows in narrow layout     |
-| `--tbx-mat-banner-overlay-shadow`  | M3 level 3    | Overlay panel drop shadow             |
+| Property                           | Default       | Description                                   |
+| ---------------------------------- | ------------- | --------------------------------------------- |
+| `--tbx-mat-banner-padding`         | `0.5rem 1rem` | Host element padding                          |
+| `--tbx-mat-banner-font-size`       | `inherit`     | Message text size                             |
+| `--tbx-mat-banner-icon-size`       | `1.5rem`      | Severity icon size                            |
+| `--tbx-mat-banner-label-gap`       | `1rem`        | Gap between icon and message                  |
+| `--tbx-mat-banner-actions-gap`     | `0.5rem`      | Gap between controls in actions group         |
+| `--tbx-mat-banner-actions-padding` | `1rem`        | Padding before actions area                   |
+| `--tbx-mat-banner-close-gap`       | `0.5rem`      | Gap between actions and close button          |
+| `--tbx-mat-banner-controls-gap`    | `0.75rem`     | Gap between input controls                    |
+| `--tbx-mat-banner-buttons-gap`     | `0.5rem`      | Gap between action buttons                    |
+| `--tbx-mat-banner-actions-row-gap` | `0.5rem`      | Gap between rows in narrow layout             |
+| `--tbx-mat-banner-overlay-shadow`  | M3 level 3    | Overlay panel drop shadow (consumer override) |
+| `--tbx-mat-banner-overlay-z-index` | `1000`        | Z-index of the overlay panel                  |
+
+#### Animation
+
+Effective only when `animation` is `Slide` or `Fade`. Ignored when `None`.
+
+| Property                               | Default                            | Description            |
+| -------------------------------------- | ---------------------------------- | ---------------------- |
+| `--tbx-mat-banner-anim-enter-duration` | `300ms`                            | Enter animation length |
+| `--tbx-mat-banner-anim-enter-easing`   | `cubic-bezier(0.25, 0.8, 0.25, 1)` | Enter easing curve     |
+| `--tbx-mat-banner-anim-exit-duration`  | `250ms`                            | Exit animation length  |
+| `--tbx-mat-banner-anim-exit-easing`    | `cubic-bezier(0.4, 0, 0.6, 1)`     | Exit easing curve      |
 
 #### Colors
 
@@ -316,6 +356,14 @@ Returned synchronously from all service methods.
 | `ProgrammaticDismissAll`     | `dismissAll()` called         |
 | `ProgrammaticDismissCurrent` | `dismiss()` called            |
 
+### TbxMatBannerAnimation
+
+| Value   | Description                                                              |
+| ------- | ------------------------------------------------------------------------ |
+| `None`  | No animation — instant show/hide (default)                               |
+| `Slide` | Slides in/out from the closest viewport edge based on `verticalPosition` |
+| `Fade`  | Fades in/out via opacity                                                 |
+
 ### TbxMatBannerConfig
 
 | Property           | Type                                | Default | Description                                    |
@@ -328,13 +376,15 @@ Returned synchronously from all service methods.
 | `actionsGroup`     | `TbxMatBannerActionsGroupControl[]` | -       | Array of buttons and form controls             |
 | `panelClass`       | `string \| string[]`                | -       | Additional CSS classes for the overlay panel   |
 | `verticalPosition` | `'top' \| 'bottom'`                 | `'top'` | Overlay position (overlay mode only)           |
+| `animation`        | `TbxMatBannerAnimation`             | `None`  | Enter/exit animation (overlay mode only)       |
 
 ### TbxMatBannerProviderConfig
 
-| Property                      | Type                                                                     | Default      | Description                       |
-| ----------------------------- | ------------------------------------------------------------------------ | ------------ | --------------------------------- |
-| `severityIconResolverService` | `TbxMatSeverityResolver & TbxMatIconResolver<TbxMatSeverityLevel> & ...` | -            | Severity icon resolver (required) |
-| `closeIconResolverService`    | `TbxMatIconResolver<string> & { iconType }`                              | Default font | Close button icon resolver        |
+| Property                      | Type                                                                     | Default      | Description                                                         |
+| ----------------------------- | ------------------------------------------------------------------------ | ------------ | ------------------------------------------------------------------- |
+| `severityIconResolverService` | `TbxMatSeverityResolver & TbxMatIconResolver<TbxMatSeverityLevel> & ...` | -            | Severity icon resolver (required)                                   |
+| `closeIconResolverService`    | `TbxMatIconResolver<string> & { iconType }`                              | Default font | Close button icon resolver                                          |
+| `defaultAnimation`            | `TbxMatBannerAnimation`                                                  | `None`       | App-wide default animation; per-banner `animation` takes precedence |
 
 ## Compatibility
 

--- a/docs/reference/workflows/ci.md
+++ b/docs/reference/workflows/ci.md
@@ -74,7 +74,7 @@ The reusable workflow performs the following steps:
 
 Badges are rendered by [Shields.io ↗](https://shields.io/badges/endpoint-badge) endpoint badges. The URL format is:
 
-```
+```text
 https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/{GIST_OWNER}/{GIST_ID}/raw/{REPO_NAME}-{BRANCH}-{badge}.json
 ```
 

--- a/docs/reference/workflows/claude.md
+++ b/docs/reference/workflows/claude.md
@@ -74,7 +74,7 @@ Claude reads the `CLAUDE.md` file in the repo root for project-specific context.
 
 In any issue or PR comment:
 
-```
+```text
 @claude implement this feature based on the issue description
 @claude fix the bug described above
 @claude review this PR

--- a/docs/reference/workflows/dep-compat-check.md
+++ b/docs/reference/workflows/dep-compat-check.md
@@ -25,7 +25,7 @@ Tracks pinned dependencies that are waiting for a new version — for example, w
 
 ## Configuration
 
-The local `.yml` file passes `epic-issue-number` to the reusable workflow. This must be set to the tracking issue number during repository setup (see SETUP.md step 7).
+The local `.yml` file passes `epic-issue-number` to the reusable workflow. This must be set to the tracking issue number during repository setup.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         "@angular/core": ">=21.0.0",
         "@angular/material": ">=21.0.0",
         "@teqbench/tbx-mat-icons": ">=4.0.0",
-        "@teqbench/tbx-mat-severity-icons": ">=6.0.0",
+        "@teqbench/tbx-mat-severity-icons": ">=7.0.0",
         "rxjs": ">=7.0.0"
       }
     },
@@ -5305,20 +5305,6 @@
         "@angular/compiler-cli": "^21.0.0",
         "typescript": ">=5.9 <6.0",
         "webpack": "^5.54.0"
-      }
-    },
-    "node_modules/@noble/hashes": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
-      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -15141,6 +15127,20 @@
       },
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/pkijs/node_modules/@noble/hashes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "zone.js": "^0.16.1"
   },
   "overrides": {
+    "//": "Pin vite to 7.3.2 — @angular/build bundles vite internally but does not constrain the version tightly enough; 7.4+ causes build failures with ng-packagr. Remove when @angular/build supports vite 7.4+.",
     "@angular/build": {
       "vite": "7.3.2"
     }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teqbench/tbx-mat-banners",
   "version": "0.8.0",
-  "description": "Opinionated Angular banner component and service. Provides severity-leveled methods (success, error, warning, information, help), inline or overlay display via CDK Overlay, FIFO queuing with signal-based state, indefinite duration by default, an actions group supporting buttons and form controls, optional severity icon and close button, a pure-CSS countdown bar, and dismiss reason tracking with collected control values. Supports font and SVG icons via pluggable resolver services. Designed for Angular 21+ zoneless applications.",
+  "description": "Opinionated Angular banner component and service. Provides severity-leveled methods (success, error, warning, information, help), inline or overlay display via CDK Overlay, FIFO queuing with signal-based state, indefinite duration by default, an actions group supporting buttons and form controls, optional severity icon and close button, and dismiss reason tracking with collected control values. Supports font and SVG icons via pluggable resolver services. Designed for Angular 21+ zoneless applications.",
   "type": "module",
   "exports": {
     "./styles/*": {
@@ -32,7 +32,7 @@
     "@angular/core": ">=21.0.0",
     "@angular/material": ">=21.0.0",
     "@teqbench/tbx-mat-icons": ">=4.0.0",
-    "@teqbench/tbx-mat-severity-icons": ">=6.0.0",
+    "@teqbench/tbx-mat-severity-icons": ">=7.0.0",
     "rxjs": ">=7.0.0"
   },
   "devDependenciesPinned": {

--- a/package.json
+++ b/package.json
@@ -79,8 +79,8 @@
     "vitest": "^4.0.18",
     "zone.js": "^0.16.1"
   },
+  "//overrides": "Pin vite to 7.3.2 — @angular/build bundles vite internally but does not constrain the version tightly enough; 7.4+ causes build failures with ng-packagr. Remove when @angular/build supports vite 7.4+.",
   "overrides": {
-    "//": "Pin vite to 7.3.2 — @angular/build bundles vite internally but does not constrain the version tightly enough; 7.4+ causes build failures with ng-packagr. Remove when @angular/build supports vite 7.4+.",
     "@angular/build": {
       "vite": "7.3.2"
     }

--- a/src/components/banner.component.ts
+++ b/src/components/banner.component.ts
@@ -1,5 +1,5 @@
 import { NgTemplateOutlet } from '@angular/common';
-import { ChangeDetectionStrategy, Component, computed, HostBinding, inject, input, type OnInit, output, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject, input, type OnInit, output, signal, type WritableSignal } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatCheckboxModule } from '@angular/material/checkbox';
@@ -89,6 +89,7 @@ interface ResolvedIcon {
     selector: 'tbx-mat-banner',
     imports: [NgTemplateOutlet, FormsModule, MatButtonModule, MatIconModule, MatCheckboxModule, MatSlideToggleModule, MatRadioModule, MatButtonToggleModule],
     host: {
+        '[class]': 'hostPanelClass',
         '[animate.enter]': 'resolvedData().enterAnimationClass',
         '[animate.leave]': 'resolvedData().leaveAnimationClass',
         '(animate.leave)': 'resolvedData().onLeaveAnimationDone?.()',
@@ -139,7 +140,7 @@ interface ResolvedIcon {
                             @case ('toggle-group') {
                                 <mat-button-toggle-group [multiple]="control.multiple ?? false" [value]="getControlValue(control.key)" (change)="setControlValue(control.key, $event.value)">
                                     @for (option of control.options; track option.value) {
-                                        <mat-button-toggle [value]="option.value">
+                                        <mat-button-toggle [value]="option.value" [attr.aria-label]="option.icon ? option.label : null">
                                             @if (option.icon) {
                                                 <mat-icon aria-hidden="true">{{ option.icon }}</mat-icon>
                                             } @else {
@@ -298,7 +299,6 @@ export class TbxMatBannerComponent implements OnInit {
     readonly defaultButtonAppearance = BANNER_DEFAULT_ACTION_BUTTON_APPEARANCE;
 
     /** Apply severity panel class to host element for inline mode styling. */
-    @HostBinding('class')
     get hostPanelClass(): string {
         const type = this.resolvedData().type;
         return PANEL_CLASS_MAP[type] ?? '';
@@ -332,7 +332,7 @@ export class TbxMatBannerComponent implements OnInit {
     // ── Internal state ──
 
     /** Writable signals for form control values, keyed by control key. */
-    private readonly controlValues = new Map<string, ReturnType<typeof signal>>();
+    private readonly controlValues = new Map<string, WritableSignal<unknown>>();
 
     /**
      * Resolved data — overlay DTO takes precedence, inline inputs as fallback.

--- a/src/components/banner.component.ts
+++ b/src/components/banner.component.ts
@@ -72,9 +72,8 @@ interface ResolvedIcon {
  * ```
  *
  * @example Inline mode:
- * ```typescript
- * // In template:
- * // <tbx-mat-banner [type]="severityLevel" [message]="'Hello'" (dismissed)="onDismiss($event)" />
+ * ```html
+ * <tbx-mat-banner [type]="severityLevel" [message]="'Hello'" (dismissed)="onDismiss($event)" />
  * ```
  *
  * @category Components
@@ -386,7 +385,15 @@ export class TbxMatBannerComponent implements OnInit {
         }
     }
 
-    /** Get the current value of a form control by key. */
+    /**
+     * Get the current value of a form control by key
+     *
+     * @param key - The control key to look up.
+     *
+     * @returns The current value of the control, or `undefined` if the key is not registered.
+     *
+     * @public
+     */
     getControlValue(key: string): unknown {
         return this.controlValues.get(key)?.();
     }
@@ -396,7 +403,13 @@ export class TbxMatBannerComponent implements OnInit {
         this.controlValues.get(key)?.set(value);
     }
 
-    /** Collect current values from all form controls. */
+    /**
+     * Collect current values from all form controls
+     *
+     * @returns A record keyed by control key with the current value of each form control.
+     *
+     * @public
+     */
     collectActionsGroupValues(): Record<string, unknown> {
         const values: Record<string, unknown> = {};
         for (const [key, sig] of this.controlValues) {
@@ -415,7 +428,15 @@ export class TbxMatBannerComponent implements OnInit {
         this.resolvedData().dismissByClose();
     }
 
-    /** Resolve an action button icon. */
+    /**
+     * Resolve an action button icon
+     *
+     * @param control - The action button control containing an optional icon key and resolver service.
+     *
+     * @returns The resolved icon, or `null` if no icon or resolver is configured.
+     *
+     * @public
+     */
     resolveActionIcon(control: {
         icon?: string;
         actionIconResolverService?: {

--- a/src/constants/banner.constants.ts
+++ b/src/constants/banner.constants.ts
@@ -10,19 +10,25 @@ import type { TbxMatBannerActionButtonAppearance } from '../types/banner-action-
  */
 
 /**
- * Default duration when no duration is specified (milliseconds).
+ * Default duration when no duration is specified (milliseconds)
  *
+ * @remarks
  * Used when {@link TbxMatBannerConfig.duration} is omitted.
  * Banners default to indefinite (0) — they remain visible until
  * dismissed by a user action or programmatically.
+ *
+ * @internal
  */
 export const BANNER_DEFAULT_DURATION_MS = 0;
 
 /**
- * Default action button appearance when not specified per-button.
+ * Default action button appearance when not specified per-button
  *
+ * @remarks
  * `'text'` is the lowest-emphasis button style, appropriate as a
  * default in contexts where the severity panel styling provides
  * the primary visual differentiation.
+ *
+ * @internal
  */
 export const BANNER_DEFAULT_ACTION_BUTTON_APPEARANCE: TbxMatBannerActionButtonAppearance = 'text';

--- a/src/enums/banner-animation.enum.ts
+++ b/src/enums/banner-animation.enum.ts
@@ -14,10 +14,11 @@
  *   same way on dismiss.
  * - `Fade` — fades in and out via opacity.
  *
- * Consumers can tune motion timing via the
- * `--tbx-mat-banner-anim-duration` and `--tbx-mat-banner-anim-easing`
- * CSS custom properties. Animations are automatically disabled when
- * the user has `prefers-reduced-motion: reduce` set at the OS level.
+ * Consumers can tune motion timing via four CSS custom properties:
+ * `--tbx-mat-banner-anim-enter-duration`, `--tbx-mat-banner-anim-enter-easing`,
+ * `--tbx-mat-banner-anim-exit-duration`, and `--tbx-mat-banner-anim-exit-easing`.
+ * Animations are automatically disabled when the user has
+ * `prefers-reduced-motion: reduce` set at the OS level.
  *
  * @usage
  * Set per banner via {@link TbxMatBannerConfig.animation}, or set an

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,8 @@
  * - {@link TbxMatBannerActionToggle} — toggle control in the actions group.
  * - {@link TbxMatBannerActionRadioGroup} — radio group control in the actions group.
  * - {@link TbxMatBannerActionToggleGroup} — toggle group control in the actions group.
+ * - {@link TbxMatBannerRadioOption} — option entry for radio group controls.
+ * - {@link TbxMatBannerToggleOption} — option entry for toggle group controls.
  * - {@link TbxMatBannerProviderConfig} — icon provider config interface.
  * - {@link TBX_MAT_BANNER_PROVIDER_CONFIG} — injection token for provider configuration.
  * - {@link TbxMatBannerSeverityFontIconService} — default font-based severity icon service.

--- a/src/models/banner-action-radio-group.model.ts
+++ b/src/models/banner-action-radio-group.model.ts
@@ -60,7 +60,7 @@ export interface TbxMatBannerRadioOption {
  *
  * @category Models
  * @displayName Banner Action Radio Group
- * @order 7
+ * @order 8
  * @since 1.0.0
  * @related TbxMatBannerRadioOption
  * @related TbxMatBannerConfig

--- a/src/models/banner-action-toggle-group.model.ts
+++ b/src/models/banner-action-toggle-group.model.ts
@@ -8,7 +8,7 @@
  *
  * @category Models
  * @displayName Banner Toggle Option
- * @order 8
+ * @order 9
  * @since 1.0.0
  *
  * @public
@@ -84,7 +84,7 @@ export interface TbxMatBannerToggleOption {
  *
  * @category Models
  * @displayName Banner Action Toggle Group
- * @order 8
+ * @order 10
  * @since 1.0.0
  * @related TbxMatBannerToggleOption
  * @related TbxMatBannerConfig

--- a/src/models/banner-config.model.ts
+++ b/src/models/banner-config.model.ts
@@ -162,10 +162,11 @@ export interface TbxMatBannerConfig {
      * - {@link TbxMatBannerAnimation.Fade} — fades in/out via opacity.
      *
      * Only applicable to overlay banners created via {@link TbxMatBannerService}.
-     * Consumers can override the default motion timing via the
-     * `--tbx-mat-banner-anim-duration` and `--tbx-mat-banner-anim-easing`
-     * CSS custom properties. Animations are automatically disabled when
-     * the user has `prefers-reduced-motion: reduce` set.
+     * Consumers can override the default motion timing via four CSS custom
+     * properties: `--tbx-mat-banner-anim-enter-duration`,
+     * `--tbx-mat-banner-anim-enter-easing`, `--tbx-mat-banner-anim-exit-duration`,
+     * and `--tbx-mat-banner-anim-exit-easing`. Animations are automatically
+     * disabled when the user has `prefers-reduced-motion: reduce` set.
      *
      * @public
      */

--- a/src/models/banner-config.model.ts
+++ b/src/models/banner-config.model.ts
@@ -42,6 +42,8 @@ import { type TbxMatBannerActionsGroupControl } from '../types/banner-actions-gr
  * ```
  *
  * @category Models
+ * @displayName Banner Config
+ * @order 1
  * @since 1.0.0
  * @related TbxMatBannerConfigArgs
  * @related TbxMatBannerService

--- a/src/models/banner-provider-config.model.ts
+++ b/src/models/banner-provider-config.model.ts
@@ -59,7 +59,7 @@ import { type TbxMatBannerAnimation } from '../enums/banner-animation.enum';
  *
  * @category Models
  * @displayName Banner Provider Config
- * @order 9
+ * @order 11
  * @since 1.0.0
  * @related TBX_MAT_BANNER_PROVIDER_CONFIG
  * @related TbxMatBannerSeverityFontIconService

--- a/src/services/banner-close-font-icon.service.ts
+++ b/src/services/banner-close-font-icon.service.ts
@@ -47,6 +47,7 @@ import { TbxMatFontIconService } from '@teqbench/tbx-mat-icons';
  *
  * @category Services
  * @displayName Close Font Icon Service
+ * @order 4
  * @since 1.0.0
  * @related TbxMatBannerProviderConfig
  * @related TbxMatBannerSeverityFontIconService

--- a/src/services/banner-severity-font-icon.service.ts
+++ b/src/services/banner-severity-font-icon.service.ts
@@ -55,6 +55,8 @@ import { TbxMatSeverityFontIconService, TbxMatSeverityLevel } from '@teqbench/tb
  * ```
  *
  * @category Services
+ * @displayName Severity Font Icon Service
+ * @order 2
  * @since 1.0.0
  * @related TBX_MAT_BANNER_PROVIDER_CONFIG
  * @related TbxMatBannerSeveritySvgIconService

--- a/src/services/banner-severity-svg-icon.service.spec.ts
+++ b/src/services/banner-severity-svg-icon.service.spec.ts
@@ -29,12 +29,15 @@ describe('TbxMatBannerSeveritySvgIconService', () => {
     });
 
     describe('resolve()', () => {
-        it('should resolve all severity levels to registered icon names', () => {
-            expect(service.resolve(TbxMatSeverityLevel.Success)).toBeDefined();
-            expect(service.resolve(TbxMatSeverityLevel.Error)).toBeDefined();
-            expect(service.resolve(TbxMatSeverityLevel.Warning)).toBeDefined();
-            expect(service.resolve(TbxMatSeverityLevel.Information)).toBeDefined();
-            expect(service.resolve(TbxMatSeverityLevel.Help)).toBeDefined();
+        it('should resolve all severity levels to distinct icon names', () => {
+            const results = [service.resolve(TbxMatSeverityLevel.Success), service.resolve(TbxMatSeverityLevel.Error), service.resolve(TbxMatSeverityLevel.Warning), service.resolve(TbxMatSeverityLevel.Information), service.resolve(TbxMatSeverityLevel.Help)];
+
+            for (const name of results) {
+                expect(name).toBeTypeOf('string');
+                expect(name!.length).toBeGreaterThan(0);
+            }
+
+            expect(new Set(results).size).toBe(results.length);
         });
 
         it('should return undefined for unknown keys', () => {

--- a/src/services/banner-severity-svg-icon.service.ts
+++ b/src/services/banner-severity-svg-icon.service.ts
@@ -66,6 +66,8 @@ const SVG_HELP =
  * ```
  *
  * @category Services
+ * @displayName Severity SVG Icon Service
+ * @order 3
  * @since 1.0.0
  * @related TBX_MAT_BANNER_PROVIDER_CONFIG
  * @related TbxMatBannerSeverityFontIconService

--- a/src/services/banner.service.ts
+++ b/src/services/banner.service.ts
@@ -53,7 +53,8 @@ interface QueueEntry {
  * - `pendingCount()` — number of banners waiting in the queue
  *
  * @usage
- * Inject the service and call the convenience methods for each severity level.
+ * Inject the service and call the convenience methods for each severity level
+ * (`success()`, `error()`, `warning()`, `information()`, `help()`, `default()`).
  * Use `show()` when full control over configuration is needed. Use `dismiss()`
  * and `dismissAll()` to programmatically clear banners.
  *

--- a/src/services/banner.service.ts
+++ b/src/services/banner.service.ts
@@ -100,12 +100,10 @@ export class TbxMatBannerService {
     private readonly defaultCloseIconService = new TbxMatBannerCloseFontIconService();
     private destroyed = false;
 
-    constructor() {
-        inject(DestroyRef).onDestroy(() => {
-            this.destroyed = true;
-            this.cleanupActive();
-        });
-    }
+    private readonly _destroyCleanup = inject(DestroyRef).onDestroy(() => {
+        this.destroyed = true;
+        this.cleanupActive();
+    });
 
     /** FIFO queue of pending banners. */
     private readonly queue: QueueEntry[] = [];

--- a/src/types/banner-actions-group-control.type.ts
+++ b/src/types/banner-actions-group-control.type.ts
@@ -10,7 +10,7 @@ import { type TbxMatBannerActionToggleGroup } from '../models/banner-action-togg
  * @remarks
  * Each control in a banner's `actionsGroup` array must be one of these types.
  * The `type` property serves as the discriminant for type narrowing in
- * `@switch` blocks and conditional logic.
+ * `\@switch` blocks and conditional logic.
  *
  * Controls are rendered in the slot between the banner's message and close
  * button, in array order.


### PR DESCRIPTION
## Summary

- docs(readme): update documentation for animation, signal inputs, and CSS properties
- fix(ci): move vite override comment to top-level key to unbreak npm ci
- fix: address post-0.8.0 code review findings (#49) — a11y, Angular conventions, TypeScript, test assertions, docs accuracy, config cleanup
- docs: address post-0.8.0 AI friendliness audit findings (#56) — TSDoc tags, @returns, README API table, code block languages, prose versions

## Test plan

- [ ] `npm run typecheck` passes
- [ ] `npm run lint` passes
- [ ] `npm test` passes (121 tests)
- [ ] `npm run format:check` passes
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)