### PR TITLE
feat(build): ship docs manifests in the published tarball

### DIFF
--- a/ng-package.json
+++ b/ng-package.json
@@ -9,6 +9,11 @@
       "input": "src/styles",
       "glob": "**/*",
       "output": "styles"
+    },
+    {
+      "input": "docs",
+      "glob": "*.{md,yml}",
+      "output": "docs"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Add \`docs/\` as an ng-packagr asset scoped to top-level \`*.md\` and \`*.yml\`.
- Consumer-facing manifests (\`overview.md\`, \`features.yml\`, \`concepts.yml\`, \`related.yml\`, \`accessibility.md\`) ship in the published tarball; internal \`docs/reference/\` developer docs stay out.
- Unblocks teqbench.website reading per-package manifests directly from \`node_modules\` at build time, keeping website content version-aligned with the installed release.

Tarball delta: ~8 KB across the five manifests.

## Test plan

- [x] \`npm run build\` succeeds and \`dist/docs/\` contains the five manifests
- [x] \`npm pack --dry-run\` inside \`dist/\` lists all five docs files and excludes \`docs/reference/\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)