### PR TITLE
ci(pages): add thin caller for the reusable Docs Deploy workflow

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -1,0 +1,17 @@
+# Thin caller — delegates to the org-wide reusable Docs Deploy workflow.
+# See: https://github.com/teqbench/.github/.github/workflows/docs-deploy.yml
+
+name: TeqBench Package - Docs Deploy Workflow
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: docs-deploy-${{ github.repository }}
+  cancel-in-progress: false
+
+jobs:
+  docs-deploy:
+    uses: teqbench/.github/.github/workflows/docs-deploy.yml@main
+    secrets: inherit


### PR DESCRIPTION
## Summary

Thin caller that delegates to the org-wide reusable \`docs-deploy.yml\` workflow in \`teqbench/.github\`. On every push to \`main\`, builds \`storybook-docs-static/\` via \`npm run build-storybook:docs\` and deploys it to GitHub Pages.

Target URL after first successful deploy: https://teqbench.github.io/tbx-mat-banners/

## Prerequisites (already satisfied)

- [x] Reusable workflow present on \`main\` of \`teqbench/.github\` (teqbench/.github#8)
- [x] \`build-storybook:docs\` npm script exists (PR #68)
- [x] Repo Pages configured with Source: GitHub Actions

## Test plan

- [ ] Merge this to \`dev\`, then carry \`dev → main\` via \`release/*\`
- [ ] First push to \`main\` triggers the workflow; verify Pages deploy succeeds
- [ ] Visit https://teqbench.github.io/tbx-mat-banners/ and confirm the docs Storybook renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)