### PR TITLE
release: docs manifests in tarball + Pages deploy

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -1,0 +1,17 @@
+# Thin caller — delegates to the org-wide reusable Docs Deploy workflow.
+# See: https://github.com/teqbench/.github/.github/workflows/docs-deploy.yml
+
+name: TeqBench Package - Docs Deploy Workflow
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: docs-deploy-${{ github.repository }}
+  cancel-in-progress: false
+
+jobs:
+  docs-deploy:
+    uses: teqbench/.github/.github/workflows/docs-deploy.yml@main
+    secrets: inherit

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,8 @@ yarn-error.log
 
 # Storybook
 storybook-static/
+storybook-dev-static/
+storybook-docs-static/
 
 # Testing
 /coverage/

--- a/.storybook-config/main.base.ts
+++ b/.storybook-config/main.base.ts
@@ -1,0 +1,24 @@
+import type { StorybookConfig } from '@analogjs/storybook-angular';
+
+/**
+ * Shared Storybook main config fragments used by both the dev and docs
+ * Storybook instances. Each instance spreads this into its own `StorybookConfig`
+ * and adds its own `stories` glob and any instance-specific addons.
+ */
+export const baseConfig: Omit<StorybookConfig, 'stories'> & { features?: Record<string, boolean> } = {
+    addons: [],
+    features: {
+        actions: false,
+        interactions: false,
+        measure: false,
+        outline: false,
+    },
+    framework: {
+        name: '@analogjs/storybook-angular',
+        options: {},
+    },
+    core: {
+        disableTelemetry: true,
+        disableWhatsNewNotifications: true,
+    },
+};

--- a/.storybook-config/preview-head.html
+++ b/.storybook-config/preview-head.html
@@ -1,0 +1,4 @@
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
+<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200" rel="stylesheet" />

--- a/.storybook-config/preview.base.ts
+++ b/.storybook-config/preview.base.ts
@@ -1,0 +1,53 @@
+import type { Preview } from '@storybook/angular';
+import { applicationConfig } from '@storybook/angular';
+import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
+import { MAT_ICON_DEFAULT_OPTIONS } from '@angular/material/icon';
+import { TBX_MAT_BANNER_PROVIDER_CONFIG } from '../src/tokens/banner-provider-config.token';
+import { TbxMatBannerSeverityFontIconService } from '../src/services/banner-severity-font-icon.service';
+
+// M3 prebuilt theme — provides typography, shape, and state-layer tokens.
+import '@angular/material/prebuilt-themes/azure-blue.css';
+
+// Banner component styles, imported directly from source so both dev and docs
+// Storybooks pick up in-repo changes without requiring a package rebuild.
+import '../src/styles/_tbx-mat-banners.scss';
+
+/**
+ * Shared preview configuration used by both Storybook instances. Each
+ * instance spreads this into its own `Preview` and adds any instance-specific
+ * decorators, parameters, or story-sort rules on top.
+ */
+export const basePreview: Preview = {
+    decorators: [
+        applicationConfig({
+            providers: [
+                provideAnimationsAsync(),
+                {
+                    provide: MAT_ICON_DEFAULT_OPTIONS,
+                    useValue: { fontSet: 'material-symbols-rounded' },
+                },
+                {
+                    provide: TBX_MAT_BANNER_PROVIDER_CONFIG,
+                    useFactory: () => ({
+                        severityIconResolverService: new TbxMatBannerSeverityFontIconService('material-symbols-rounded'),
+                    }),
+                },
+            ],
+        }),
+    ],
+    parameters: {
+        backgrounds: { disable: true },
+        controls: {
+            disableSaveFromUI: true,
+            matchers: {
+                color: /(background|color)$/i,
+                date: /Date$/i,
+            },
+        },
+        actions: { disable: true },
+        interactions: { disable: true },
+        measure: { disable: true },
+        outline: { disable: true },
+        grid: { disable: true },
+    },
+};

--- a/.storybook-config/vite.config.ts
+++ b/.storybook-config/vite.config.ts
@@ -1,0 +1,3 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({});

--- a/.storybook-dev/main.ts
+++ b/.storybook-dev/main.ts
@@ -1,0 +1,24 @@
+import type { StorybookConfig } from '@analogjs/storybook-angular';
+import { baseConfig } from '../.storybook-config/main.base.ts';
+
+/**
+ * Development Storybook — development-facing harnesses colocated with the
+ * components they exercise under `src/components/`. Includes component-level
+ * stories that are useful while implementing the library but are not intended
+ * for end-consumer documentation.
+ */
+const config: StorybookConfig = {
+    ...baseConfig,
+    stories: ['../src/components/**/*.stories.@(ts|mdx)'],
+    core: {
+        ...baseConfig.core,
+        builder: {
+            name: '@storybook/builder-vite',
+            options: {
+                viteConfigPath: '.storybook-config/vite.config.ts',
+            },
+        },
+    },
+};
+
+export default config;

--- a/.storybook-dev/preview-head.html
+++ b/.storybook-dev/preview-head.html
@@ -1,0 +1,4 @@
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
+<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200" rel="stylesheet" />

--- a/.storybook-dev/preview.ts
+++ b/.storybook-dev/preview.ts
@@ -1,0 +1,32 @@
+import type { Preview } from '@storybook/angular';
+import { basePreview } from '../.storybook-config/preview.base.ts';
+import { removeStoryOverrideStyleTag } from '../src/components/story-overrides';
+
+/**
+ * Development preview — extends the shared base and adds the
+ * `removeStoryOverrideStyleTag` decorator that clears any story-specific
+ * document-level style overrides between navigations. The dev stories inject
+ * one-off overrides at document scope to pierce CDK overlay encapsulation;
+ * this decorator prevents those overrides from leaking across stories.
+ */
+const preview: Preview = {
+    ...basePreview,
+    decorators: [
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (story: () => any) => {
+            removeStoryOverrideStyleTag();
+            return story();
+        },
+        ...(basePreview.decorators ?? []),
+    ],
+    parameters: {
+        ...basePreview.parameters,
+        options: {
+            storySort: {
+                order: ['Banners', ['Overlay']],
+            },
+        },
+    },
+};
+
+export default preview;

--- a/.storybook-dev/tsconfig.json
+++ b/.storybook-dev/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "types": ["node"],
+    "allowImportingTsExtensions": true
+  },
+  "include": ["../src/components/**/*.stories.ts", "../src/components/**/*.stories.mdx", "./main.ts", "./preview.ts", "../.storybook-config/**/*.ts"],
+  "exclude": ["../src/**/*.spec.ts"]
+}

--- a/.storybook-docs/main.ts
+++ b/.storybook-docs/main.ts
@@ -1,0 +1,24 @@
+import type { StorybookConfig } from '@analogjs/storybook-angular';
+import { baseConfig } from '../.storybook-config/main.base.ts';
+
+/**
+ * Documentation Storybook — consumer-facing demos intended for publication
+ * (GitHub Pages) and for embedding in the teqbench.website package pages.
+ * Stories live under `src/stories/` and each one is a self-contained, narrated
+ * harness with richer inline explanations.
+ */
+const config: StorybookConfig = {
+    ...baseConfig,
+    stories: ['../src/stories/**/*.stories.@(ts|mdx)'],
+    core: {
+        ...baseConfig.core,
+        builder: {
+            name: '@storybook/builder-vite',
+            options: {
+                viteConfigPath: '.storybook-config/vite.config.ts',
+            },
+        },
+    },
+};
+
+export default config;

--- a/.storybook-docs/manager.ts
+++ b/.storybook-docs/manager.ts
@@ -1,0 +1,27 @@
+import { addons } from 'storybook/manager-api';
+
+/**
+ * Sidebar tag filter activated via the `filter` URL parameter. When this
+ * Storybook is embedded in the teqbench.website demos iframe, the iframe URL
+ * includes `&filter={packageTag}` (e.g. `&filter=banners`) which scopes the
+ * sidebar to stories tagged with that value. When viewed standalone (no
+ * `filter` param), the full story list is shown.
+ */
+function getFilterTag(): string | null {
+    return new URLSearchParams(location.search).get('filter');
+}
+
+addons.setConfig({
+    disableSaveFromUI: true,
+    enableShortcuts: false,
+    selectedPanel: 'addon-controls',
+    sidebar: {
+        filters: {
+            patterns: (item) => {
+                const filterTag = getFilterTag();
+                if (!filterTag) return true;
+                return (item.tags || []).includes(filterTag);
+            },
+        },
+    },
+});

--- a/.storybook-docs/preview-head.html
+++ b/.storybook-docs/preview-head.html
@@ -1,0 +1,4 @@
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
+<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200" rel="stylesheet" />

--- a/.storybook-docs/preview.ts
+++ b/.storybook-docs/preview.ts
@@ -1,0 +1,28 @@
+import type { Preview } from '@storybook/angular';
+import { basePreview } from '../.storybook-config/preview.base.ts';
+
+/**
+ * Documentation preview — extends the shared base with a narrative story sort
+ * order (simple → complex → customization) and opens stories in `docs` view
+ * mode so the published site renders the autodocs page by default.
+ */
+const preview: Preview = {
+    ...basePreview,
+    parameters: {
+        ...basePreview.parameters,
+        options: {
+            storySort: (a, b) => {
+                const ORDER = ['banners--inline', 'banners--overlays', 'banners--overlays-actions', 'banners--custom'];
+                const aIdx = ORDER.indexOf(a.id);
+                const bIdx = ORDER.indexOf(b.id);
+                if (aIdx === -1 && bIdx === -1) return a.id.localeCompare(b.id);
+                if (aIdx === -1) return 1;
+                if (bIdx === -1) return -1;
+                return aIdx - bIdx;
+            },
+        },
+        viewMode: 'docs',
+    },
+};
+
+export default preview;

--- a/.storybook-docs/tsconfig.json
+++ b/.storybook-docs/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "types": ["node"],
+    "allowImportingTsExtensions": true
+  },
+  "include": ["../src/stories/**/*.stories.ts", "../src/stories/**/*.stories.mdx", "./main.ts", "./preview.ts", "./manager.ts", "../.storybook-config/**/*.ts"],
+  "exclude": ["../src/**/*.spec.ts"]
+}

--- a/README.md
+++ b/README.md
@@ -2,15 +2,61 @@
 
 ![Build Status](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/teqbench-shields-bot/a69600f4ed4ebed89ffb35d808e05eb4/raw/tbx-mat-banners-main-build-status.json) ![Tests](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/teqbench-shields-bot/a69600f4ed4ebed89ffb35d808e05eb4/raw/tbx-mat-banners-main-tests.json) ![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/teqbench-shields-bot/a69600f4ed4ebed89ffb35d808e05eb4/raw/tbx-mat-banners-main-coverage.json) ![Version](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/teqbench-shields-bot/a69600f4ed4ebed89ffb35d808e05eb4/raw/tbx-mat-banners-main-version.json) ![Build Number](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/teqbench-shields-bot/a69600f4ed4ebed89ffb35d808e05eb4/raw/tbx-mat-banners-main-build-number.json)
 
-> An opinionated [Angular ↗](https://angular.dev) banner component and service. Provides `TbxMatBannerService` for overlay display via [CDK Overlay ↗](https://material.angular.dev/cdk/overlay/api) and `TbxMatBannerComponent` for inline display. Features severity-leveled methods (`success()`, `error()`, `warning()`, `information()`, `help()`), an actions group supporting buttons and form controls (checkbox, toggle, radio group, toggle group), FIFO queuing with signal-based state, indefinite duration by default, and dismiss reason tracking with collected control values.
+> An opinionated [Angular ↗](https://angular.dev) banner component and service with severity-leveled display, an actions group supporting buttons and form controls, and both overlay and inline display modes.
+
+<details>
+<summary><strong>Table of contents</strong></summary>
+
+- [Overview](#overview)
+- [At a glance](#at-a-glance)
+- [When to use](#when-to-use)
+- [Installation](#installation)
+- [Usage](#usage)
+- [Concepts](#concepts)
+- [API Reference](#api-reference)
+- [Styling](#styling)
+- [Accessibility](#accessibility)
+- [Compatibility](#compatibility)
+- [Related packages](#related-packages)
+- [Versioning & releases](#versioning--releases)
+- [Contributing](#contributing)
+- [Security](#security)
+- [Feedback](#feedback)
+- [License](#license)
+
+</details>
+
+## Overview
+
+`@teqbench/tbx-mat-banners` provides persistent, attention-grabbing messages for [Angular ↗](https://angular.dev) applications. It fills the gap between small transient notifications and heavier modal dialogs: a wide, horizontally full banner that can carry a short message, a severity indicator, and a small group of action controls, and that stays on screen until the user — or application code — dismisses it.
+
+Two display modes are supported from a single component surface. In **overlay mode**, `TbxMatBannerService` creates banners via [CDK Overlay ↗](https://material.angular.dev/cdk/overlay/api) on a FIFO queue, one at a time, with optional slide or fade animation and programmatic dismiss. In **inline mode**, `TbxMatBannerComponent` is placed directly in a template, controlled by the consumer via bindings, and emits dismiss events.
+
+Severity (`success`, `error`, `warning`, `information`, `help`) drives both the icon and the color scheme, via dedicated CSS custom properties independent of the active [M3 ↗](https://m3.material.io) theme palette. An optional actions group accepts any mix of buttons, checkboxes, toggles, radio groups, and toggle groups; on dismiss, all collected values are returned alongside the dismiss reason and the action key that triggered it.
+
+The library is designed for [Angular ↗](https://angular.dev) 21+ zoneless applications, uses [signal inputs ↗](https://angular.dev/guide/signals/inputs), honors `prefers-reduced-motion`, and exposes a pluggable icon resolver so consumers can use [Material Symbols ↗](https://fonts.google.com/icons) font icons or bundled SVG icons without changing component code.
+
+## At a glance
+
+- **Two display modes** — overlay service for fire-and-forget messages and inline component for template-driven use.
+- **Severity-leveled API** — convenience methods for success, error, warning, information, and help with matching icons and colors.
+- **Actions group** — buttons and form controls (checkbox, toggle, radio group, toggle group) in a single message.
+- **FIFO queue** — one banner at a time, with signal-based `isActive` and `pendingCount` state.
+- **Dismiss tracking** — promise resolves with dismiss reason, action key, and collected form control values.
+- **Indefinite by default** — banners persist until dismissed; positive duration auto-dismisses, negative is treated as indefinite.
+- **Animations** — optional slide or fade on overlay banners; automatically disabled under `prefers-reduced-motion`.
+- **Theming via CSS custom properties** — per-severity colors, gaps, padding, shadow, and z-index exposed as CSS variables.
+- **Pluggable icons** — [Material Symbols ↗](https://fonts.google.com/icons) font icons or SVG icon resolver service via DI token.
+- **Responsive layout** — CSS container queries reflow the actions group onto a second row on narrow viewports.
+- **Zoneless ready** — built for [Angular ↗](https://angular.dev) 21+ zoneless applications using [signal inputs ↗](https://angular.dev/guide/signals/inputs).
 
 ## When to use
 
 Banners are one of three message surfaces in the TeqBench component family. Choose based on the weight of the message and how much interaction it needs:
 
-- [`@teqbench/tbx-mat-notifications`](https://github.com/teqbench/tbx-mat-notifications) — small, transient messages with at most one action control. Ideally one line of text, two lines acceptable. Use notifications to acknowledge something without interrupting the user's flow.
+- [`@teqbench/tbx-mat-notifications` ↗](https://github.com/teqbench/tbx-mat-notifications) — small, transient messages with at most one action control. Ideally one line of text, two lines acceptable. Use notifications to acknowledge something without interrupting the user's flow.
 - **`@teqbench/tbx-mat-banners`** (this package) — wide, persistent messages with multiple action controls. Ideally one line of message text, up to three lines still acceptable. Use a banner when the message needs the user's attention and may offer a few follow-up choices.
-- [`@teqbench/tbx-mat-dialogs`](https://github.com/teqbench/tbx-mat-dialogs) — heavier, focused interactions for arbitrary content. Use a dialog when the message is long, the choices are many, or the interaction is complex.
+- [`@teqbench/tbx-mat-dialogs` ↗](https://github.com/teqbench/tbx-mat-dialogs) — heavier, focused interactions for arbitrary content. Use a dialog when the message is long, the choices are many, or the interaction is complex.
 
 If the content you are putting in a banner is approaching the three-line limit, or if the actions group is growing beyond a handful of controls, that is a signal to escalate to a dialog instead. A banner that behaves like a miniature dialog loses the affordances of both.
 
@@ -202,114 +248,15 @@ providers: [
 ];
 ```
 
-### CSS Custom Properties
+## Concepts
 
-Banner appearance is customizable via CSS custom properties. Set them globally on `html` or scope them to a panel class for per-severity overrides.
-
-#### Layout
-
-| Property                           | Default       | Description                                   |
-| ---------------------------------- | ------------- | --------------------------------------------- |
-| `--tbx-mat-banner-padding`         | `0.5rem 1rem` | Host element padding                          |
-| `--tbx-mat-banner-font-size`       | `inherit`     | Message text size                             |
-| `--tbx-mat-banner-icon-size`       | `1.5rem`      | Severity icon size                            |
-| `--tbx-mat-banner-label-gap`       | `1rem`        | Gap between icon and message                  |
-| `--tbx-mat-banner-actions-gap`     | `0.5rem`      | Gap between controls in actions group         |
-| `--tbx-mat-banner-actions-padding` | `1rem`        | Padding before actions area                   |
-| `--tbx-mat-banner-close-gap`       | `0.5rem`      | Gap between actions and close button          |
-| `--tbx-mat-banner-controls-gap`    | `0.75rem`     | Gap between input controls                    |
-| `--tbx-mat-banner-buttons-gap`     | `0.5rem`      | Gap between action buttons                    |
-| `--tbx-mat-banner-actions-row-gap` | `0.5rem`      | Gap between rows in narrow layout             |
-| `--tbx-mat-banner-overlay-shadow`  | M3 level 3    | Overlay panel drop shadow (consumer override) |
-| `--tbx-mat-banner-overlay-z-index` | `1000`        | Z-index of the overlay panel                  |
-
-#### Animation
-
-Effective only when `animation` is `Slide` or `Fade`. Ignored when `None`.
-
-| Property                               | Default                            | Description            |
-| -------------------------------------- | ---------------------------------- | ---------------------- |
-| `--tbx-mat-banner-anim-enter-duration` | `300ms`                            | Enter animation length |
-| `--tbx-mat-banner-anim-enter-easing`   | `cubic-bezier(0.25, 0.8, 0.25, 1)` | Enter easing curve     |
-| `--tbx-mat-banner-anim-exit-duration`  | `250ms`                            | Exit animation length  |
-| `--tbx-mat-banner-anim-exit-easing`    | `cubic-bezier(0.4, 0, 0.6, 1)`     | Exit easing curve      |
-
-#### Colors
-
-| Property                                  | Default                                                            | Description                 |
-| ----------------------------------------- | ------------------------------------------------------------------ | --------------------------- |
-| `--tbx-mat-banner-success-background`     | ![#2E7D32](https://placehold.co/15x15/2E7D32/2E7D32.png) `#2E7D32` | Success background          |
-| `--tbx-mat-banner-success-text`           | ![#FFFFFF](https://placehold.co/15x15/FFFFFF/FFFFFF.png) `#FFFFFF` | Success text/icon color     |
-| `--tbx-mat-banner-error-background`       | ![#C62828](https://placehold.co/15x15/C62828/C62828.png) `#C62828` | Error background            |
-| `--tbx-mat-banner-error-text`             | ![#FFFFFF](https://placehold.co/15x15/FFFFFF/FFFFFF.png) `#FFFFFF` | Error text/icon color       |
-| `--tbx-mat-banner-warning-background`     | ![#F9A825](https://placehold.co/15x15/F9A825/F9A825.png) `#F9A825` | Warning background          |
-| `--tbx-mat-banner-warning-text`           | ![#FFFFFF](https://placehold.co/15x15/FFFFFF/FFFFFF.png) `#FFFFFF` | Warning text/icon color     |
-| `--tbx-mat-banner-information-background` | ![#1565C0](https://placehold.co/15x15/1565C0/1565C0.png) `#1565C0` | Information background      |
-| `--tbx-mat-banner-information-text`       | ![#FFFFFF](https://placehold.co/15x15/FFFFFF/FFFFFF.png) `#FFFFFF` | Information text/icon color |
-| `--tbx-mat-banner-help-background`        | ![#1976D2](https://placehold.co/15x15/1976D2/1976D2.png) `#1976D2` | Help background             |
-| `--tbx-mat-banner-help-text`              | ![#FFFFFF](https://placehold.co/15x15/FFFFFF/FFFFFF.png) `#FFFFFF` | Help text/icon color        |
-
-### Styling Font Icons
-
-[Material Symbols ↗](https://fonts.google.com/icons) are variable fonts that expose four CSS axes via `font-variation-settings`. Target the overlay panel class to scope changes to banners.
-
-#### State transition (outlined to filled)
-
-```css
-@keyframes tbx-banner-icon-fill {
-    from {
-        font-variation-settings:
-            'FILL' 0,
-            'wght' 400,
-            'GRAD' 0,
-            'opsz' 24;
-    }
-    to {
-        font-variation-settings:
-            'FILL' 1,
-            'wght' 400,
-            'GRAD' 0,
-            'opsz' 24;
-    }
-}
-.tbx-mat-banner-overlay-panel .material-symbols-rounded {
-    animation: tbx-banner-icon-fill 0.3s ease-in-out 0.15s forwards;
-    font-variation-settings:
-        'FILL' 0,
-        'wght' 400,
-        'GRAD' 0,
-        'opsz' 24;
-}
-```
-
-#### Pulse (continuous loop)
-
-```css
-@keyframes tbx-banner-icon-pulse {
-    from {
-        font-variation-settings:
-            'FILL' 0,
-            'wght' 400,
-            'GRAD' 0,
-            'opsz' 24;
-    }
-    to {
-        font-variation-settings:
-            'FILL' 1,
-            'wght' 400,
-            'GRAD' 0,
-            'opsz' 24;
-    }
-}
-.tbx-mat-banner-overlay-panel .tbx-mat-banner-icon {
-    animation: tbx-banner-icon-pulse 1s ease-in-out infinite alternate;
-    font-variation-settings:
-        'FILL' 0,
-        'wght' 400,
-        'GRAD' 0,
-        'opsz' 24;
-}
-```
+- **Severity level** — a classification (success, error, warning, information, help) that selects the icon and color scheme applied to a banner.
+- **Actions group** — an ordered list of action controls, buttons and form controls, rendered inside the banner and whose values are returned on dismiss.
+- **Dismiss reason** — the cause of a banner closing: user action, close button, timeout, or one of two programmatic paths (single or all).
+- **Queue** — a FIFO list of pending banners. One banner is visible at a time in overlay mode; queued banners render in order as each resolves.
+- **Provider config** — the DI-provided configuration (`TBX_MAT_BANNER_PROVIDER_CONFIG`) that supplies the severity icon resolver, optional close icon resolver, and default animation.
+- **Inline mode** — using `TbxMatBannerComponent` directly in a consumer template, with visibility and state controlled by the consumer rather than the service.
+- **Overlay mode** — using `TbxMatBannerService` to render a banner in a CDK Overlay above the application, positioned at the top or bottom of the viewport.
 
 ## API Reference
 
@@ -386,17 +333,154 @@ Returned synchronously from all service methods.
 | `closeIconResolverService`    | `TbxMatIconResolver<string> & { iconType }`                              | Default font | Close button icon resolver                                          |
 | `defaultAnimation`            | `TbxMatBannerAnimation`                                                  | `None`       | App-wide default animation; per-banner `animation` takes precedence |
 
+## Styling
+
+Banner appearance is customizable via CSS custom properties. Set them globally on `html` or scope them to a panel class for per-severity overrides.
+
+### Layout
+
+| Property                           | Default       | Description                                   |
+| ---------------------------------- | ------------- | --------------------------------------------- |
+| `--tbx-mat-banner-padding`         | `0.5rem 1rem` | Host element padding                          |
+| `--tbx-mat-banner-font-size`       | `inherit`     | Message text size                             |
+| `--tbx-mat-banner-icon-size`       | `1.5rem`      | Severity icon size                            |
+| `--tbx-mat-banner-label-gap`       | `1rem`        | Gap between icon and message                  |
+| `--tbx-mat-banner-actions-gap`     | `0.5rem`      | Gap between controls in actions group         |
+| `--tbx-mat-banner-actions-padding` | `1rem`        | Padding before actions area                   |
+| `--tbx-mat-banner-close-gap`       | `0.5rem`      | Gap between actions and close button          |
+| `--tbx-mat-banner-controls-gap`    | `0.75rem`     | Gap between input controls                    |
+| `--tbx-mat-banner-buttons-gap`     | `0.5rem`      | Gap between action buttons                    |
+| `--tbx-mat-banner-actions-row-gap` | `0.5rem`      | Gap between rows in narrow layout             |
+| `--tbx-mat-banner-overlay-shadow`  | M3 level 3    | Overlay panel drop shadow (consumer override) |
+| `--tbx-mat-banner-overlay-z-index` | `1000`        | Z-index of the overlay panel                  |
+
+### Animation
+
+Effective only when `animation` is `Slide` or `Fade`. Ignored when `None`.
+
+| Property                               | Default                            | Description            |
+| -------------------------------------- | ---------------------------------- | ---------------------- |
+| `--tbx-mat-banner-anim-enter-duration` | `300ms`                            | Enter animation length |
+| `--tbx-mat-banner-anim-enter-easing`   | `cubic-bezier(0.25, 0.8, 0.25, 1)` | Enter easing curve     |
+| `--tbx-mat-banner-anim-exit-duration`  | `250ms`                            | Exit animation length  |
+| `--tbx-mat-banner-anim-exit-easing`    | `cubic-bezier(0.4, 0, 0.6, 1)`     | Exit easing curve      |
+
+### Colors
+
+| Property                                  | Default   | Description                 |
+| ----------------------------------------- | --------- | --------------------------- |
+| `--tbx-mat-banner-success-background`     | `#2E7D32` | Success background          |
+| `--tbx-mat-banner-success-text`           | `#FFFFFF` | Success text/icon color     |
+| `--tbx-mat-banner-error-background`       | `#C62828` | Error background            |
+| `--tbx-mat-banner-error-text`             | `#FFFFFF` | Error text/icon color       |
+| `--tbx-mat-banner-warning-background`     | `#F9A825` | Warning background          |
+| `--tbx-mat-banner-warning-text`           | `#FFFFFF` | Warning text/icon color     |
+| `--tbx-mat-banner-information-background` | `#1565C0` | Information background      |
+| `--tbx-mat-banner-information-text`       | `#FFFFFF` | Information text/icon color |
+| `--tbx-mat-banner-help-background`        | `#1976D2` | Help background             |
+| `--tbx-mat-banner-help-text`              | `#FFFFFF` | Help text/icon color        |
+
+### Styling Font Icons
+
+[Material Symbols ↗](https://fonts.google.com/icons) are variable fonts that expose four CSS axes via `font-variation-settings`. Target the overlay panel class to scope changes to banners.
+
+#### State transition (outlined to filled)
+
+```css
+@keyframes tbx-banner-icon-fill {
+    from {
+        font-variation-settings:
+            'FILL' 0,
+            'wght' 400,
+            'GRAD' 0,
+            'opsz' 24;
+    }
+    to {
+        font-variation-settings:
+            'FILL' 1,
+            'wght' 400,
+            'GRAD' 0,
+            'opsz' 24;
+    }
+}
+.tbx-mat-banner-overlay-panel .material-symbols-rounded {
+    animation: tbx-banner-icon-fill 0.3s ease-in-out 0.15s forwards;
+    font-variation-settings:
+        'FILL' 0,
+        'wght' 400,
+        'GRAD' 0,
+        'opsz' 24;
+}
+```
+
+#### Pulse (continuous loop)
+
+```css
+@keyframes tbx-banner-icon-pulse {
+    from {
+        font-variation-settings:
+            'FILL' 0,
+            'wght' 400,
+            'GRAD' 0,
+            'opsz' 24;
+    }
+    to {
+        font-variation-settings:
+            'FILL' 1,
+            'wght' 400,
+            'GRAD' 0,
+            'opsz' 24;
+    }
+}
+.tbx-mat-banner-overlay-panel .tbx-mat-banner-icon {
+    animation: tbx-banner-icon-pulse 1s ease-in-out infinite alternate;
+    font-variation-settings:
+        'FILL' 0,
+        'wght' 400,
+        'GRAD' 0,
+        'opsz' 24;
+}
+```
+
+## Accessibility
+
+- **Overlay container.** Overlay banners render inside a [CDK Overlay ↗](https://material.angular.dev/cdk/overlay/api) pane positioned at the top or bottom of the viewport. The overlay is non-blocking and does not trap focus. Consumers that need screen-reader announcement of new banners should wrap the banner message in a container with `aria-live="polite"` in their application shell, or use the [LiveAnnouncer ↗](https://material.angular.dev/cdk/a11y/api#LiveAnnouncer) service to announce the message text alongside the banner call.
+- **Keyboard.** The close button and every control in the actions group are focusable in DOM order. `Enter` and `Space` activate buttons; form controls use their native [Angular Material ↗](https://material.angular.dev) keyboard behavior.
+- **Focus.** Focus is not moved into the banner automatically — banners are non-blocking. Consumers that need to direct attention to a banner action should call `focus()` on the control explicitly, or escalate to a dialog.
+- **Reduced motion.** When `prefers-reduced-motion: reduce` is set, the `Slide` and `Fade` animations are bypassed and banners show/hide instantly regardless of the configured animation.
+- **Color contrast.** The default severity palette meets [WCAG ↗](https://www.w3.org/WAI/standards-guidelines/wcag/) AA contrast for body text on each background. Overriding the severity CSS custom properties is the consumer's responsibility to re-verify.
+- **Icons.** Severity icons are decorative and marked `aria-hidden`; the severity meaning is carried by the message text itself, not by the icon alone.
+
 ## Compatibility
 
-| Dependency                                                                             | Version  |
-| -------------------------------------------------------------------------------------- | -------- |
-| [Angular ↗](https://angular.dev)                                                       | >=21.0.0 |
-| [Angular CDK ↗](https://material.angular.dev/cdk)                                      | >=21.0.0 |
-| [Angular Material ↗](https://material.angular.dev)                                     | >=21.0.0 |
-| [@teqbench/tbx-mat-icons](https://github.com/teqbench/tbx-mat-icons)                   | >=4.0.0  |
-| [@teqbench/tbx-mat-severity-icons](https://github.com/teqbench/tbx-mat-severity-icons) | >=7.0.0  |
-| [TypeScript ↗](https://www.typescriptlang.org)                                         | ~5.9.0   |
-| [Node.js ↗](https://nodejs.org)                                                        | >=24.0.0 |
+| Dependency                                                                               | Version  |
+| ---------------------------------------------------------------------------------------- | -------- |
+| [Angular ↗](https://angular.dev)                                                         | >=21.0.0 |
+| [Angular CDK ↗](https://material.angular.dev/cdk)                                        | >=21.0.0 |
+| [Angular Material ↗](https://material.angular.dev)                                       | >=21.0.0 |
+| [@teqbench/tbx-mat-icons ↗](https://github.com/teqbench/tbx-mat-icons)                   | >=4.0.0  |
+| [@teqbench/tbx-mat-severity-icons ↗](https://github.com/teqbench/tbx-mat-severity-icons) | >=7.0.0  |
+| [TypeScript ↗](https://www.typescriptlang.org)                                           | ~5.9.0   |
+| [Node.js ↗](https://nodejs.org)                                                          | >=24.0.0 |
+
+## Related packages
+
+- [`@teqbench/tbx-mat-notifications` ↗](https://github.com/teqbench/tbx-mat-notifications) — transient, single-action messages for lightweight acknowledgements.
+- [`@teqbench/tbx-mat-dialogs` ↗](https://github.com/teqbench/tbx-mat-dialogs) — modal dialogs for heavier, focused interactions.
+- [`@teqbench/tbx-mat-severity-icons` ↗](https://github.com/teqbench/tbx-mat-severity-icons) — severity icon resolver base services reused by this package.
+- [`@teqbench/tbx-mat-icons` ↗](https://github.com/teqbench/tbx-mat-icons) — shared icon resolver contracts and base services.
+
+## Versioning & releases
+
+This package follows [Semantic Versioning ↗](https://semver.org). Versions and changelog entries are produced automatically by [Release Please ↗](https://github.com/googleapis/release-please) from [Conventional Commits ↗](https://www.conventionalcommits.org) on `main`. See [CHANGELOG.md](CHANGELOG.md) for the full release history.
+
+## Contributing
+
+Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for local setup, [GitHub Packages ↗](https://github.com/orgs/teqbench/packages) authentication, branch conventions, commit format, and the PR workflow.
+
+## Security
+
+See [SECURITY.md](SECURITY.md) for the supported-version policy and how to report a vulnerability privately.
 
 ## Feedback
 
@@ -405,4 +489,4 @@ Returned synchronously from all service methods.
 
 ## License
 
-[AGPL-3.0](LICENSE) -- Copyright 2026 TeqBench
+[AGPL-3.0](LICENSE) — Copyright 2026 TeqBench

--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -1,0 +1,8 @@
+# Accessibility
+
+- **Overlay container.** Overlay banners render inside a [CDK Overlay ↗](https://material.angular.dev/cdk/overlay/api) pane positioned at the top or bottom of the viewport. The overlay is non-blocking and does not trap focus. Consumers that need screen-reader announcement of new banners should wrap the banner message in a container with `aria-live="polite"` in their application shell, or use the existing [LiveAnnouncer ↗](https://material.angular.dev/cdk/a11y/api#LiveAnnouncer) service to announce the message text alongside the banner call.
+- **Keyboard.** The close button and every control in the actions group are focusable in DOM order. `Enter` and `Space` activate buttons; form controls use their native [Angular Material ↗](https://material.angular.dev) keyboard behavior.
+- **Focus.** Focus is not moved into the banner automatically — banners are non-blocking. Consumers that need to direct attention to a banner action should call `focus()` on the control explicitly, or escalate to a dialog.
+- **Reduced motion.** When `prefers-reduced-motion: reduce` is set, the `Slide` and `Fade` animations are bypassed and banners show/hide instantly regardless of the configured animation.
+- **Color contrast.** The default severity palette meets [WCAG ↗](https://www.w3.org/WAI/standards-guidelines/wcag/) AA contrast for body text on each background. Overriding the severity CSS custom properties is the consumer's responsibility to re-verify.
+- **Icons.** Severity icons are decorative and marked `aria-hidden`; the severity meaning is carried by the message text itself, not by the icon alone.

--- a/docs/concepts.yml
+++ b/docs/concepts.yml
@@ -1,0 +1,15 @@
+# Glossary rendered in the README "Concepts" section. Term -> one-line definition.
+- term: Severity level
+  definition: A classification (success, error, warning, information, help) that selects the icon and color scheme applied to a banner.
+- term: Actions group
+  definition: An ordered list of action controls — buttons and form controls — rendered inside the banner and whose values are returned on dismiss.
+- term: Dismiss reason
+  definition: The cause of a banner closing — user action, close button, timeout, or one of two programmatic paths (single or all).
+- term: Queue
+  definition: A FIFO list of pending banners. One banner is visible at a time in overlay mode; queued banners render in order as each resolves.
+- term: Provider config
+  definition: The DI-provided configuration (TBX_MAT_BANNER_PROVIDER_CONFIG) that supplies the severity icon resolver, optional close icon resolver, and default animation.
+- term: Inline mode
+  definition: Using TbxMatBannerComponent directly in a consumer template, with visibility and state controlled by the consumer rather than the service.
+- term: Overlay mode
+  definition: Using TbxMatBannerService to render a banner in a CDK Overlay above the application, positioned at the top or bottom of the viewport.

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -1,0 +1,24 @@
+# Short, scannable feature bullets rendered in the README "At a glance" section.
+# Each entry: one short noun phrase, one-line explanation.
+- name: Two display modes
+  summary: Overlay service for fire-and-forget messages and inline component for template-driven use.
+- name: Severity-leveled API
+  summary: Convenience methods for success, error, warning, information, and help with matching icons and colors.
+- name: Actions group
+  summary: Buttons and form controls (checkbox, toggle, radio group, toggle group) in a single message.
+- name: FIFO queue
+  summary: One banner at a time, with signal-based isActive and pendingCount state.
+- name: Dismiss tracking
+  summary: Promise resolves with dismiss reason, action key, and collected form control values.
+- name: Indefinite by default
+  summary: Banners persist until dismissed; positive duration auto-dismisses, negative is treated as indefinite.
+- name: Animations
+  summary: Optional slide or fade on overlay banners; automatically disabled under prefers-reduced-motion.
+- name: Theming via CSS custom properties
+  summary: Per-severity colors, gaps, padding, shadow, and z-index exposed as CSS variables.
+- name: Pluggable icons
+  summary: Font (Material Symbols) or SVG icon resolver service via DI token.
+- name: Responsive layout
+  summary: CSS container queries reflow the actions group onto a second row on narrow viewports.
+- name: Zoneless ready
+  summary: Built for Angular 21+ zoneless applications using signal inputs.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,23 @@
+---
+tagline: An opinionated [Angular ↗](https://angular.dev) banner component and service with severity-leveled display, an actions group supporting buttons and form controls, and both overlay and inline display modes.
+---
+
+## Overview
+
+`@teqbench/tbx-mat-banners` provides persistent, attention-grabbing messages for [Angular ↗](https://angular.dev) applications. It fills the gap between small transient notifications and heavier modal dialogs: a wide, horizontally full banner that can carry a short message, a severity indicator, and a small group of action controls, and that stays on screen until the user — or application code — dismisses it.
+
+Two display modes are supported from a single component surface. In **overlay mode**, `TbxMatBannerService` creates banners via [CDK Overlay ↗](https://material.angular.dev/cdk/overlay/api) on a FIFO queue, one at a time, with optional slide or fade animation and programmatic dismiss. In **inline mode**, `TbxMatBannerComponent` is placed directly in a template, controlled by the consumer via bindings, and emits dismiss events.
+
+Severity (`success`, `error`, `warning`, `information`, `help`) drives both the icon and the color scheme, via dedicated CSS custom properties independent of the active [M3 ↗](https://m3.material.io) theme palette. An optional actions group accepts any mix of buttons, checkboxes, toggles, radio groups, and toggle groups; on dismiss, all collected values are returned alongside the dismiss reason and the action key that triggered it.
+
+The library is designed for [Angular ↗](https://angular.dev) 21+ zoneless applications, uses [signal inputs ↗](https://angular.dev/guide/signals/inputs), honors `prefers-reduced-motion`, and exposes a pluggable icon resolver so consumers can use [Material Symbols ↗](https://fonts.google.com/icons) font icons or bundled SVG icons without changing component code.
+
+## When to use
+
+Banners are one of three message surfaces in the TeqBench component family. Choose based on the weight of the message and how much interaction it needs.
+
+- [`@teqbench/tbx-mat-notifications` ↗](https://github.com/teqbench/tbx-mat-notifications) — small, transient messages with at most one action control. Ideally one line of text, two lines acceptable. Use notifications to acknowledge something without interrupting the user's flow.
+- **`@teqbench/tbx-mat-banners`** (this package) — wide, persistent messages with multiple action controls. Ideally one line of message text, up to three lines still acceptable. Use a banner when the message needs the user's attention and may offer a few follow-up choices.
+- [`@teqbench/tbx-mat-dialogs` ↗](https://github.com/teqbench/tbx-mat-dialogs) — heavier, focused interactions for arbitrary content. Use a dialog when the message is long, the choices are many, or the interaction is complex.
+
+If the content you are putting in a banner is approaching the three-line limit, or if the actions group is growing beyond a handful of controls, that is a signal to escalate to a dialog instead. A banner that behaves like a miniature dialog loses the affordances of both.

--- a/docs/related.yml
+++ b/docs/related.yml
@@ -1,0 +1,13 @@
+# Sibling @teqbench packages rendered in the README "Related packages" section.
+- name: "@teqbench/tbx-mat-notifications"
+  url: https://github.com/teqbench/tbx-mat-notifications
+  summary: Transient, single-action messages for lightweight acknowledgements.
+- name: "@teqbench/tbx-mat-dialogs"
+  url: https://github.com/teqbench/tbx-mat-dialogs
+  summary: Modal dialogs for heavier, focused interactions.
+- name: "@teqbench/tbx-mat-severity-icons"
+  url: https://github.com/teqbench/tbx-mat-severity-icons
+  summary: Severity icon resolver base services reused by this package.
+- name: "@teqbench/tbx-mat-icons"
+  url: https://github.com/teqbench/tbx-mat-icons
+  summary: Shared icon resolver contracts and base services.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,7 +4,7 @@ import tsdoc from 'eslint-plugin-tsdoc';
 
 export default tseslint.config(
     {
-        ignores: ['.claude/', '.shared-skills/', '.storybook/', 'coverage/', 'dist/', 'node_modules/', 'storybook-static/'],
+        ignores: ['.claude/', '.shared-skills/', '.storybook/', '.storybook-config/', '.storybook-dev/', '.storybook-docs/', 'coverage/', 'dist/', 'node_modules/', 'storybook-static/', 'storybook-dev-static/', 'storybook-docs-static/'],
     },
     ...tseslint.configs.recommended,
     ...angular.configs.tsRecommended,

--- a/ng-package.json
+++ b/ng-package.json
@@ -9,6 +9,11 @@
       "input": "src/styles",
       "glob": "**/*",
       "output": "styles"
+    },
+    {
+      "input": "docs",
+      "glob": "*.{md,yml}",
+      "output": "docs"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -23,8 +23,12 @@
     "test:coverage": "vitest run --coverage",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build",
+    "storybook": "storybook dev -p 6006 -c .storybook-dev",
+    "storybook:dev": "storybook dev -p 6006 -c .storybook-dev",
+    "storybook:docs": "storybook dev -p 6007 -c .storybook-docs",
+    "build-storybook": "storybook build -c .storybook-dev -o storybook-dev-static",
+    "build-storybook:dev": "storybook build -c .storybook-dev -o storybook-dev-static",
+    "build-storybook:docs": "storybook build -c .storybook-docs -o storybook-docs-static",
     "prepare": "husky"
   },
   "peerDependencies": {

--- a/src/stories/banners/banner-custom.stories.ts
+++ b/src/stories/banners/banner-custom.stories.ts
@@ -1,0 +1,335 @@
+import { Component, effect, inject, input } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import type { Meta, StoryObj } from '@storybook/angular';
+import { moduleMetadata } from '@storybook/angular';
+import { TbxMatBannerAnimation, TbxMatBannerService } from '../../index';
+
+type VerticalPosition = 'top' | 'bottom';
+type EnterExitAnimation = 'none' | 'slide' | 'fade';
+
+// Custom panel styles applied via the `panelClass` config option on the
+// banner service. The styles are injected once at the document level so they
+// reach the overlay (which renders outside the component tree via CDK portal).
+// The consumer panel class (e.g. tbx-demo-brand) is applied to the CDK
+// overlay pane, while the severity styling (background/color) is applied to
+// the tbx-mat-banner component host inside the pane. To visually customize
+// the banner surface, target the tbx-mat-banner descendant.
+const CUSTOM_PANEL_CSS = `
+  /* Brand-colored banner: indigo background, white text/icon */
+  .tbx-demo-brand tbx-mat-banner {
+    background-color: #4f46e5;
+    color: #ffffff;
+    --tbx-mat-banner-action-icon-color: #ffffff;
+    --tbx-mat-banner-close-icon-color: #ffffff;
+  }
+
+  /* Dark mode banner: dark slate background, light indigo icon */
+  .tbx-demo-dark tbx-mat-banner {
+    background-color: #1e293b;
+    color: #e2e8f0;
+    --tbx-mat-banner-action-icon-color: #a5b4fc;
+    --tbx-mat-banner-close-icon-color: #a5b4fc;
+  }
+
+  /* Gradient banner: diagonal indigo to pink gradient */
+  .tbx-demo-gradient tbx-mat-banner {
+    background: linear-gradient(135deg, #6366f1 0%, #ec4899 100%);
+    color: #ffffff;
+    --tbx-mat-banner-action-icon-color: #ffffff;
+    --tbx-mat-banner-close-icon-color: #ffffff;
+  }
+
+  /* Fully rounded "pill" shape with generous horizontal padding */
+  .tbx-demo-pill tbx-mat-banner {
+    border-radius: 999px;
+    margin: 0.5rem;
+    background-color: #fef3c7;
+    color: #78350f;
+    --tbx-mat-banner-action-icon-color: #b45309;
+    --tbx-mat-banner-close-icon-color: #b45309;
+  }
+
+  /* Outlined style: white fill with colored border */
+  .tbx-demo-outlined tbx-mat-banner {
+    background-color: #ffffff;
+    border: 2px solid #10b981;
+    color: #064e3b;
+    --tbx-mat-banner-action-icon-color: #10b981;
+    --tbx-mat-banner-close-icon-color: #10b981;
+  }
+
+  /* Severity override: repaint the built-in success theme in teal. */
+  .tbx-demo-teal-success tbx-mat-banner {
+    background-color: #0d9488;
+    color: #f0fdfa;
+    --tbx-mat-banner-action-icon-color: #f0fdfa;
+    --tbx-mat-banner-close-icon-color: #f0fdfa;
+  }
+`;
+
+@Component({
+    selector: 'tbx-banner-custom-harness',
+    imports: [MatButtonModule],
+    template: `
+        <div class="harness">
+            <div class="instructions">
+                <p>
+                    <strong>Custom banner styling</strong> goes beyond the built-in severity themes. The banner service accepts a <code>panelClass</code> config option — any CSS class (or array of classes) that gets added to the
+                    <a href="https://material.angular.dev/cdk/overlay/api" target="_blank" rel="noopener">CDK Overlay</a>
+                    pane hosting the banner.
+                </p>
+
+                <h4>How the DOM is structured</h4>
+                <p>When a banner opens, the CDK produces this DOM tree (simplified):</p>
+                <pre>
+&lt;div class="cdk-overlay-pane tbx-mat-banner-overlay-panel
+     tbx-mat-banner-position-top
+     <strong>my-custom-class</strong>"&gt;
+  &lt;tbx-mat-banner class="tbx-mat-banner-panel-success"&gt;
+    ...icon, message, actions...
+  &lt;/tbx-mat-banner&gt;
+&lt;/div&gt;</pre
+                >
+                <p>Your <code>panelClass</code> is applied to the <strong>outer pane</strong>, but the visible banner surface (background, border, padding) belongs to the inner <code>&lt;tbx-mat-banner&gt;</code> component host. To style that surface, target it as a descendant of your panel class:</p>
+                <pre>
+.my-custom-class tbx-mat-banner &#123;
+  background-color: #4f46e5;
+  color: #ffffff;
+&#125;</pre
+                >
+
+                <h4>Theming buttons and icons via CSS custom properties</h4>
+                <p>The banner exposes a set of CSS custom properties consumed by its internal buttons, severity icon, and close icon. Setting these on your panel class themes every inner element consistently — no need to target individual button classes:</p>
+                <ul>
+                    <li><code>--tbx-mat-banner-action-icon-color</code> — color for icon-only action buttons in the actions group</li>
+                    <li><code>--tbx-mat-banner-close-icon-color</code> — color for the close (<span>&times;</span>) button in the top-right corner</li>
+                    <li><code>--mat-button-filled-container-color</code>, <code>--mat-button-filled-label-text-color</code> — filled button background and text</li>
+                    <li><code>--mat-button-outlined-outline-color</code>, <code>--mat-button-outlined-label-text-color</code> — outlined button border and text</li>
+                    <li>(and equivalent tokens for <code>tonal</code>, <code>text</code>, <code>elevated</code> button variants plus <code>checkbox</code>, <code>toggle</code>, and <code>radio</code> controls)</li>
+                </ul>
+                <p>Look at <code>_tbx-mat-banners.scss</code> in the package to see the full token list and the <code>_severity-panel</code> mixin that maps them for the built-in severities.</p>
+
+                <h4>Demos below</h4>
+                <ul>
+                    <li><strong>Brand &amp; Color Themes</strong> — solid colors, dark mode, and a gradient background, each overriding the banner surface and icon tokens.</li>
+                    <li><strong>Shape &amp; Layout Variations</strong> — fully-rounded pill shape and an outlined style (white fill with a green border) that depart from the default rectangular severity styling.</li>
+                    <li><strong>Severity Override</strong> — the most targeted use of <code>panelClass</code>: called alongside <code>banner.success(&hellip;)</code> so both <code>tbx-mat-banner-panel-success</code> and the custom class are present, letting the override repaint just that one severity.</li>
+                </ul>
+            </div>
+
+            <h3>Brand &amp; Color Themes</h3>
+            <div class="button-group">
+                <button mat-flat-button (click)="brand()">Brand Indigo</button>
+                <button mat-flat-button (click)="dark()">Dark Mode</button>
+                <button mat-flat-button (click)="gradient()">Gradient</button>
+            </div>
+
+            <h3>Shape &amp; Layout Variations</h3>
+            <div class="button-group">
+                <button mat-flat-button (click)="pill()">Pill Shape</button>
+                <button mat-flat-button (click)="outlined()">Outlined</button>
+            </div>
+
+            <h3>Severity Override</h3>
+            <p class="theme-note">The panel class can coexist with a severity method to override just that severity's appearance — here <code>success</code> is repainted with a teal theme.</p>
+            <div class="button-group">
+                <button mat-flat-button (click)="tealSuccess()">Teal Success</button>
+            </div>
+
+            <h3>Queue</h3>
+            <div class="button-group">
+                <button mat-flat-button (click)="banner.dismissAll()">Dismiss All</button>
+            </div>
+            <p class="state">Active: {{ banner.isActive() }} &middot; Pending: {{ banner.pendingCount() }}</p>
+        </div>
+    `,
+    styles: [
+        `
+            .harness {
+                font-family: Roboto, sans-serif;
+                padding: 1.5rem;
+            }
+            h3 {
+                margin: 1.5rem 0 0.5rem;
+            }
+            h3:first-of-type {
+                margin-top: 0;
+            }
+            .instructions {
+                font-size: 0.875rem;
+                color: #555;
+                background: #f8f9fa;
+                border: 1px solid #e0e0e0;
+                border-radius: 8px;
+                padding: 0.75rem 1rem;
+                margin-bottom: 1.5rem;
+                line-height: 1.6;
+            }
+            .instructions code,
+            .theme-note code {
+                background: #eef2ff;
+                color: #4338ca;
+                padding: 0.1em 0.35em;
+                border-radius: 3px;
+                font-size: 0.9em;
+            }
+            .instructions h4 {
+                margin: 1rem 0 0.375rem;
+                font-size: 0.875rem;
+                font-weight: 600;
+                color: #1e293b;
+            }
+            .instructions p {
+                margin: 0 0 0.5rem;
+            }
+            .instructions ul {
+                margin: 0 0 0.5rem;
+                padding-left: 1.25rem;
+            }
+            .instructions li {
+                margin-bottom: 0.125rem;
+            }
+            .instructions pre {
+                background: #1e293b;
+                color: #e2e8f0;
+                padding: 0.75rem 1rem;
+                border-radius: 6px;
+                overflow-x: auto;
+                font-size: 0.8125rem;
+                font-family: 'SF Mono', 'Fira Code', Consolas, monospace;
+                margin: 0 0 0.75rem;
+            }
+            .instructions pre code,
+            .instructions pre strong {
+                background: transparent;
+                color: inherit;
+                padding: 0;
+                font-size: inherit;
+            }
+            .instructions pre strong {
+                color: #a5b4fc;
+                font-weight: 600;
+            }
+            .instructions a {
+                color: #4338ca;
+            }
+            .button-group {
+                display: flex;
+                flex-wrap: wrap;
+                gap: 0.5rem;
+            }
+            .state {
+                margin-top: 1rem;
+                font-size: 0.875rem;
+                color: #666;
+            }
+            .theme-note {
+                font-size: 0.8125rem;
+                color: #666;
+                border-left: 3px solid #ddd;
+                padding: 0.25rem 0.75rem;
+                margin: 0 0 1rem;
+            }
+        `,
+    ],
+})
+class BannerCustomHarnessComponent {
+    readonly banner = inject(TbxMatBannerService);
+
+    readonly verticalPosition = input<VerticalPosition>('top');
+    readonly enterExitAnimation = input<EnterExitAnimation>('none');
+
+    constructor() {
+        // Inject the custom panel styles once at the document level so they
+        // reach the CDK-rendered overlay banners.
+        const STYLE_ID = 'tbx-banner-story-custom-panels';
+
+        effect(() => {
+            if (document.getElementById(STYLE_ID)) return;
+            const style = document.createElement('style');
+            style.id = STYLE_ID;
+            style.textContent = CUSTOM_PANEL_CSS;
+            document.head.appendChild(style);
+        });
+    }
+
+    private fire(message: string, panelClass: string): void {
+        this.banner.default(message, {
+            panelClass,
+            verticalPosition: this.verticalPosition(),
+            animation: this.mapAnimation(),
+        });
+    }
+
+    private mapAnimation(): TbxMatBannerAnimation {
+        switch (this.enterExitAnimation()) {
+            case 'slide':
+                return TbxMatBannerAnimation.Slide;
+            case 'fade':
+                return TbxMatBannerAnimation.Fade;
+            default:
+                return TbxMatBannerAnimation.None;
+        }
+    }
+
+    brand(): void {
+        this.fire('TeqBench brand colors — indigo background with white text.', 'tbx-demo-brand');
+    }
+
+    dark(): void {
+        this.fire('Dark mode banner with light indigo accent icon.', 'tbx-demo-dark');
+    }
+
+    gradient(): void {
+        this.fire('Gradient background from indigo to pink.', 'tbx-demo-gradient');
+    }
+
+    pill(): void {
+        this.fire('Fully rounded pill shape with amber background.', 'tbx-demo-pill');
+    }
+
+    outlined(): void {
+        this.fire('Outlined style — transparent background with emerald border.', 'tbx-demo-outlined');
+    }
+
+    tealSuccess(): void {
+        // Use the success severity method but with a custom panel class that
+        // repaints the success theme in teal.
+        this.banner.success('Deployment complete — repainted in teal via panel class override.', {
+            panelClass: 'tbx-demo-teal-success',
+            verticalPosition: this.verticalPosition(),
+            animation: this.mapAnimation(),
+        });
+    }
+}
+
+const meta: Meta<BannerCustomHarnessComponent> = {
+    title: 'Banners',
+    tags: ['banners'],
+    component: BannerCustomHarnessComponent,
+    decorators: [moduleMetadata({ imports: [BannerCustomHarnessComponent] })],
+    argTypes: {
+        verticalPosition: {
+            name: 'Position',
+            control: 'select',
+            options: ['top', 'bottom'],
+            description: 'Vertical position of the overlay banner',
+        },
+        enterExitAnimation: {
+            name: 'Enter/Exit Animation',
+            control: 'select',
+            options: ['none', 'slide', 'fade'],
+            description: 'Enter and exit animation mode',
+        },
+    },
+};
+
+export default meta;
+type Story = StoryObj<BannerCustomHarnessComponent>;
+
+export const Custom: Story = {
+    args: {
+        verticalPosition: 'top',
+        enterExitAnimation: 'none',
+    },
+};

--- a/src/stories/banners/banner-inline.stories.ts
+++ b/src/stories/banners/banner-inline.stories.ts
@@ -1,0 +1,357 @@
+import { Component, computed, effect, input, signal } from '@angular/core';
+import { JsonPipe } from '@angular/common';
+import { MatButtonModule } from '@angular/material/button';
+import type { Meta, StoryObj } from '@storybook/angular';
+import { moduleMetadata } from '@storybook/angular';
+import { TbxMatSeverityLevel } from '@teqbench/tbx-mat-severity-icons';
+import { TbxMatBannerComponent, type TbxMatBannerResult, type TbxMatBannerActionsGroupControl } from '../../index';
+
+@Component({
+    selector: 'tbx-banner-inline-harness',
+    imports: [MatButtonModule, JsonPipe, TbxMatBannerComponent],
+    template: `
+        <div class="harness" [style]="iconSizeStyle()">
+            <div class="instructions">
+                <p><strong>Inline banners</strong> render directly in your template, flowing with the surrounding page content rather than overlaying it. The consumer controls visibility via <code>&#64;if</code> / signals (unlike overlay banners which are managed by <code>TbxMatBannerService</code>). Place a <code>&lt;tbx-mat-banner&gt;</code> element wherever the message belongs in the DOM.</p>
+                <p>Every example below uses a different banner configuration — severity level, action buttons, or form controls. Severity panel classes (<code>tbx-mat-banner-panel-*</code>) are applied to the component host automatically based on the <code>[type]</code> input. Dismiss events fire via the <code>(dismissed)</code> output and include the action key plus collected control values. The <strong>Controls</strong> panel below adjusts icon size and icon animation across all banners on this page.</p>
+            </div>
+
+            <h3>Severity Levels</h3>
+            <div class="severity-stack">
+                <tbx-mat-banner [type]="defaultLevel" message="Default — no severity styling applied." [style.display]="isDismissed('default') ? 'none' : ''" (dismissed)="onDismiss('default', $event)" />
+                @if (isDismissed('default')) {
+                    <p class="dismissed-note">Dismissed. <button mat-button (click)="show('default')">Show again</button></p>
+                }
+
+                <tbx-mat-banner [type]="successLevel" message="Success — operation completed." [style.display]="isDismissed('success') ? 'none' : ''" (dismissed)="onDismiss('success', $event)" />
+                @if (isDismissed('success')) {
+                    <p class="dismissed-note">Dismissed. <button mat-button (click)="show('success')">Show again</button></p>
+                }
+
+                <tbx-mat-banner [type]="errorLevel" message="Error — something went wrong." [style.display]="isDismissed('error') ? 'none' : ''" (dismissed)="onDismiss('error', $event)" />
+                @if (isDismissed('error')) {
+                    <p class="dismissed-note">Dismissed. <button mat-button (click)="show('error')">Show again</button></p>
+                }
+
+                <tbx-mat-banner [type]="warningLevel" message="Warning — your session will expire soon." [style.display]="isDismissed('warning') ? 'none' : ''" (dismissed)="onDismiss('warning', $event)" />
+                @if (isDismissed('warning')) {
+                    <p class="dismissed-note">Dismissed. <button mat-button (click)="show('warning')">Show again</button></p>
+                }
+
+                <tbx-mat-banner [type]="informationLevel" message="Information — a new version is available." [style.display]="isDismissed('information') ? 'none' : ''" (dismissed)="onDismiss('information', $event)" />
+                @if (isDismissed('information')) {
+                    <p class="dismissed-note">Dismissed. <button mat-button (click)="show('information')">Show again</button></p>
+                }
+
+                <tbx-mat-banner [type]="helpLevel" message="Help — click the + button to add a new item." [style.display]="isDismissed('help') ? 'none' : ''" (dismissed)="onDismiss('help', $event)" />
+                @if (isDismissed('help')) {
+                    <p class="dismissed-note">Dismissed. <button mat-button (click)="show('help')">Show again</button></p>
+                }
+            </div>
+
+            <h3>With Action Buttons</h3>
+            <tbx-mat-banner [type]="warningLevel" message="Unsaved changes will be lost." [actionsGroup]="actionButtons" [style.display]="isDismissed('actions') ? 'none' : ''" (dismissed)="onDismiss('actions', $event)" />
+            @if (isDismissed('actions')) {
+                <p class="dismissed-note">Dismissed. <button mat-button (click)="show('actions')">Show again</button></p>
+            }
+
+            <h3>With Checkbox</h3>
+            <tbx-mat-banner [type]="informationLevel" message="Cookies are required for this site." [actionsGroup]="checkboxControls" [style.display]="isDismissed('checkbox') ? 'none' : ''" (dismissed)="onDismiss('checkbox', $event)" />
+            @if (isDismissed('checkbox')) {
+                <p class="dismissed-note">Dismissed. <button mat-button (click)="show('checkbox')">Show again</button></p>
+            }
+
+            <h3>With Toggle</h3>
+            <tbx-mat-banner [type]="informationLevel" message="Auto-save is disabled." [actionsGroup]="toggleControls" [style.display]="isDismissed('toggle') ? 'none' : ''" (dismissed)="onDismiss('toggle', $event)" />
+            @if (isDismissed('toggle')) {
+                <p class="dismissed-note">Dismissed. <button mat-button (click)="show('toggle')">Show again</button></p>
+            }
+
+            <h3>With Radio Group</h3>
+            <tbx-mat-banner [type]="informationLevel" message="Choose export format before proceeding." [actionsGroup]="radioGroupControls" [style.display]="isDismissed('radioGroup') ? 'none' : ''" (dismissed)="onDismiss('radioGroup', $event)" />
+            @if (isDismissed('radioGroup')) {
+                <p class="dismissed-note">Dismissed. <button mat-button (click)="show('radioGroup')">Show again</button></p>
+            }
+
+            <h3>With Toggle Group</h3>
+            <tbx-mat-banner [type]="informationLevel" message="Select notification channels." [actionsGroup]="toggleGroupControls" [style.display]="isDismissed('toggleGroup') ? 'none' : ''" (dismissed)="onDismiss('toggleGroup', $event)" />
+            @if (isDismissed('toggleGroup')) {
+                <p class="dismissed-note">Dismissed. <button mat-button (click)="show('toggleGroup')">Show again</button></p>
+            }
+
+            <h3>With Mixed Controls</h3>
+            <tbx-mat-banner [type]="informationLevel" message="Configure your preferences." [actionsGroup]="mixedControls" [style.display]="isDismissed('controls') ? 'none' : ''" (dismissed)="onDismiss('controls', $event)" />
+            @if (isDismissed('controls')) {
+                <p class="dismissed-note">Dismissed. <button mat-button (click)="show('controls')">Show again</button></p>
+            }
+
+            <h3>Narrow Container</h3>
+            <p class="theme-note">Constrained to 500px — the responsive container query wraps controls and buttons onto separate rows.</p>
+            <div class="narrow-wrapper">
+                <tbx-mat-banner [type]="informationLevel" message="Configure notification preferences." [actionsGroup]="narrowWrapControls" [style.display]="isDismissed('narrowWrap') ? 'none' : ''" (dismissed)="onDismiss('narrowWrap', $event)" />
+                @if (isDismissed('narrowWrap')) {
+                    <p class="dismissed-note">Dismissed. <button mat-button (click)="show('narrowWrap')">Show again</button></p>
+                }
+            </div>
+
+            <h3>No Close Button</h3>
+            <tbx-mat-banner [type]="errorLevel" message="This banner cannot be dismissed by the user." [showCloseButton]="false" />
+
+            <h3>No Severity Icon</h3>
+            <tbx-mat-banner [type]="helpLevel" message="This banner has no severity icon." [showSeverityIcon]="false" [style.display]="isDismissed('noIcon') ? 'none' : ''" (dismissed)="onDismiss('noIcon', $event)" />
+            @if (isDismissed('noIcon')) {
+                <p class="dismissed-note">Dismissed. <button mat-button (click)="show('noIcon')">Show again</button></p>
+            }
+
+            @if (lastResult()) {
+                <div class="result-panel">
+                    <h3>Last Dismiss Result ({{ lastSource() }})</h3>
+                    <pre>{{ lastResult() | json }}</pre>
+                </div>
+            }
+        </div>
+    `,
+    styles: [
+        `
+            .harness {
+                font-family: Roboto, sans-serif;
+                padding: 1.5rem;
+            }
+            h3 {
+                margin: 1.5rem 0 0.5rem;
+            }
+            h3:first-of-type {
+                margin-top: 0;
+            }
+            .instructions {
+                font-size: 0.875rem;
+                color: #555;
+                background: #f8f9fa;
+                border: 1px solid #e0e0e0;
+                border-radius: 8px;
+                padding: 0.75rem 1rem;
+                margin-bottom: 1.5rem;
+                line-height: 1.6;
+            }
+            .instructions p {
+                margin: 0;
+            }
+            .button-group {
+                display: flex;
+                flex-wrap: wrap;
+                gap: 0.5rem;
+            }
+            .state {
+                margin-top: 1rem;
+                font-size: 0.875rem;
+                color: #666;
+            }
+            .theme-note {
+                font-size: 0.8125rem;
+                color: #888;
+                border-left: 3px solid #ddd;
+                padding: 0.25rem 0.75rem;
+                margin: 0 0 1rem;
+            }
+            .result-panel {
+                margin-top: 1rem;
+                background: #f0f4ff;
+                border-left: 3px solid #1565c0;
+                padding: 0.5rem 0.75rem;
+            }
+            .result-panel pre {
+                font-size: 0.8125rem;
+                margin: 0.25rem 0 0;
+                white-space: pre-wrap;
+            }
+            .severity-stack {
+                display: flex;
+                flex-direction: column;
+                gap: 0.5rem;
+            }
+            .dismissed-note {
+                font-size: 0.875rem;
+                color: #666;
+            }
+            .narrow-wrapper {
+                max-width: 500px;
+                border: 1px dashed #ccc;
+            }
+        `,
+    ],
+})
+class BannerInlineHarnessComponent {
+    readonly iconSize = input<'standard' | 'medium' | 'large'>('standard');
+    readonly iconAnimation = input<'none' | 'state-transition' | 'pulse'>('none');
+
+    readonly iconSizeStyle = computed(() => {
+        const sizes = { standard: '', medium: '2rem', large: '3rem' };
+        const size = sizes[this.iconSize()];
+        return size ? `--tbx-mat-banner-icon-size: ${size}` : '';
+    });
+
+    constructor() {
+        // Reactively inject animation CSS into document.head to pierce encapsulation
+        const STYLE_ID = 'tbx-banner-story-icon-animation';
+
+        const STATE_CSS = `
+      @keyframes tbx-banner-icon-fill {
+        from { font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 24; }
+        to   { font-variation-settings: 'FILL' 1, 'wght' 400, 'GRAD' 0, 'opsz' 24; }
+      }
+      .material-symbols-rounded {
+        animation: tbx-banner-icon-fill 0.3s ease-in-out 0.15s forwards;
+        font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 24;
+      }
+    `;
+
+        const PULSE_CSS = `
+      @keyframes tbx-banner-icon-pulse {
+        from { font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 24; }
+        to   { font-variation-settings: 'FILL' 1, 'wght' 400, 'GRAD' 0, 'opsz' 24; }
+      }
+      .tbx-mat-banner-icon {
+        animation: tbx-banner-icon-pulse 1s ease-in-out infinite alternate;
+        font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 24;
+      }
+    `;
+
+        effect(() => {
+            const mode = this.iconAnimation();
+            document.getElementById(STYLE_ID)?.remove();
+            if (mode === 'none') return;
+            const style = document.createElement('style');
+            style.id = STYLE_ID;
+            style.textContent = mode === 'state-transition' ? STATE_CSS : PULSE_CSS;
+            document.head.appendChild(style);
+        });
+    }
+
+    readonly defaultLevel = TbxMatSeverityLevel.Default;
+    readonly successLevel = TbxMatSeverityLevel.Success;
+    readonly warningLevel = TbxMatSeverityLevel.Warning;
+    readonly errorLevel = TbxMatSeverityLevel.Error;
+    readonly informationLevel = TbxMatSeverityLevel.Information;
+    readonly helpLevel = TbxMatSeverityLevel.Help;
+
+    readonly dismissedKeys = signal<ReadonlySet<string>>(new Set());
+    readonly lastResult = signal<TbxMatBannerResult | null>(null);
+    readonly lastSource = signal('');
+
+    isDismissed(key: string): boolean {
+        return this.dismissedKeys().has(key);
+    }
+
+    show(key: string): void {
+        const next = new Set(this.dismissedKeys());
+        next.delete(key);
+        this.dismissedKeys.set(next);
+    }
+
+    readonly actionButtons: TbxMatBannerActionsGroupControl[] = [
+        { type: 'button', key: 'discard', label: 'Discard' },
+        { type: 'button', key: 'save', label: 'Save', appearance: 'filled' },
+    ];
+
+    readonly checkboxControls: TbxMatBannerActionsGroupControl[] = [
+        { type: 'checkbox', key: 'dontShowAgain', label: "Don't show again", defaultValue: false },
+        { type: 'button', key: 'accept', label: 'Accept', appearance: 'filled' },
+    ];
+
+    readonly toggleControls: TbxMatBannerActionsGroupControl[] = [
+        { type: 'toggle', key: 'autoSave', label: 'Enable auto-save', defaultValue: false },
+        { type: 'button', key: 'confirm', label: 'Confirm', appearance: 'filled' },
+    ];
+
+    readonly radioGroupControls: TbxMatBannerActionsGroupControl[] = [
+        {
+            type: 'radio-group',
+            key: 'format',
+            options: [
+                { label: 'JSON', value: 'json' },
+                { label: 'CSV', value: 'csv' },
+                { label: 'XML', value: 'xml' },
+            ],
+            defaultValue: 'json',
+        },
+        { type: 'button', key: 'export', label: 'Export', appearance: 'filled' },
+    ];
+
+    readonly toggleGroupControls: TbxMatBannerActionsGroupControl[] = [
+        {
+            type: 'toggle-group',
+            key: 'channels',
+            multiple: true,
+            options: [
+                { label: 'Email', value: 'email' },
+                { label: 'SMS', value: 'sms' },
+                { label: 'Push', value: 'push' },
+            ],
+            defaultValue: ['email'],
+        },
+        { type: 'button', key: 'save', label: 'Save', appearance: 'filled' },
+    ];
+
+    readonly narrowWrapControls: TbxMatBannerActionsGroupControl[] = [
+        { type: 'checkbox', key: 'email', label: 'Email', defaultValue: true },
+        { type: 'checkbox', key: 'sms', label: 'SMS', defaultValue: false },
+        { type: 'checkbox', key: 'push', label: 'Push', defaultValue: true },
+        { type: 'button', key: 'cancel', label: 'Cancel' },
+        { type: 'button', key: 'reset', label: 'Reset', appearance: 'outlined' },
+        { type: 'button', key: 'save', label: 'Save', appearance: 'filled' },
+    ];
+
+    readonly mixedControls: TbxMatBannerActionsGroupControl[] = [
+        { type: 'checkbox', key: 'autoUpdate', label: 'Auto-update', defaultValue: true },
+        {
+            type: 'radio-group',
+            key: 'channel',
+            options: [
+                { label: 'Stable', value: 'stable' },
+                { label: 'Beta', value: 'beta' },
+            ],
+            defaultValue: 'stable',
+        },
+        { type: 'button', key: 'cancel', label: 'Cancel' },
+        { type: 'button', key: 'apply', label: 'Apply', appearance: 'filled' },
+    ];
+
+    onDismiss(source: string, result: TbxMatBannerResult): void {
+        this.lastSource.set(source);
+        this.lastResult.set(result);
+        const next = new Set(this.dismissedKeys());
+        next.add(source);
+        this.dismissedKeys.set(next);
+    }
+}
+
+const meta: Meta<BannerInlineHarnessComponent> = {
+    title: 'Banners',
+    tags: ['banners'],
+    component: BannerInlineHarnessComponent,
+    decorators: [moduleMetadata({ imports: [BannerInlineHarnessComponent] })],
+    argTypes: {
+        iconSize: {
+            name: 'Icon Size',
+            control: 'select',
+            options: ['standard', 'medium', 'large'],
+            description: 'Severity icon size',
+        },
+        iconAnimation: {
+            name: 'Icon Animation',
+            control: 'select',
+            options: ['none', 'state-transition', 'pulse'],
+            description: 'Icon fill animation',
+        },
+    },
+};
+
+export default meta;
+type Story = StoryObj<BannerInlineHarnessComponent>;
+
+export const Inline: Story = {
+    args: {
+        iconSize: 'standard',
+        iconAnimation: 'none',
+    },
+};

--- a/src/stories/banners/banner-overlay-actions.stories.ts
+++ b/src/stories/banners/banner-overlay-actions.stories.ts
@@ -1,0 +1,478 @@
+import { Component, effect, inject, input, signal } from '@angular/core';
+import { JsonPipe } from '@angular/common';
+import { MatButtonModule } from '@angular/material/button';
+import type { Meta, StoryObj } from '@storybook/angular';
+import { moduleMetadata } from '@storybook/angular';
+import { TbxMatIconType } from '@teqbench/tbx-mat-icons';
+import { TbxMatBannerAnimation, TbxMatBannerService, type TbxMatBannerResult, type TbxMatBannerActionsGroupControl } from '../../index';
+
+type Severity = 'default' | 'success' | 'error' | 'warning' | 'information' | 'help';
+type VerticalPosition = 'top' | 'bottom';
+type EnterExitAnimation = 'none' | 'slide' | 'fade';
+type IconSize = 'standard' | 'medium' | 'large';
+type IconAnimation = 'none' | 'state-transition' | 'pulse';
+
+// Simple font icon resolver for the story — resolves Material Symbols ligature
+// names as-is (the name IS the ligature, e.g., 'undo', 'download').
+const fontIconResolver = {
+    iconType: TbxMatIconType.Font,
+    resolve: (key: string) => key,
+};
+
+@Component({
+    selector: 'tbx-banner-overlay-actions-harness',
+    imports: [MatButtonModule, JsonPipe],
+    template: `
+        <div class="harness">
+            <div class="instructions">
+                <p><strong>Overlay banners with an actions group.</strong> The actions group is an array of control descriptors on the <code>actionsGroup</code> config option. Each entry is one of five types:</p>
+                <ul>
+                    <li><code>button</code> — dismisses the banner when clicked. Result contains the button's <code>key</code>. Supports five appearances (<code>text</code>, <code>filled</code>, <code>tonal</code>, <code>outlined</code>, <code>icon</code>) and optional leading or trailing icons.</li>
+                    <li><code>checkbox</code>, <code>toggle</code>, <code>radio-group</code>, <code>toggle-group</code> — form controls whose values are collected into <code>actionsGroupValues</code> on the dismiss result.</li>
+                </ul>
+                <p>Each demo below uses a <em>contextually appropriate severity level</em> for its message (not configurable — the severity is part of the example). The <strong>Controls</strong> panel below adjusts position, enter/exit animation, and icon size/animation across all demos. The "Last Dismiss Result" panel at the bottom shows the JSON result returned by the service's dismiss promise.</p>
+            </div>
+
+            <h3>Button Appearances</h3>
+            <div class="button-group">
+                <button mat-flat-button (click)="buttonsText()">Text</button>
+                <button mat-flat-button (click)="buttonsFilled()">Filled</button>
+                <button mat-flat-button (click)="buttonsTonal()">Tonal</button>
+                <button mat-flat-button (click)="buttonsOutlined()">Outlined</button>
+                <button mat-flat-button (click)="buttonsMixed()">Mixed Appearances</button>
+            </div>
+
+            <h3>Buttons with Icons</h3>
+            <div class="button-group">
+                <button mat-flat-button (click)="buttonsLeadingIcons()">Leading Icons</button>
+                <button mat-flat-button (click)="buttonsTrailingIcons()">Trailing Icons</button>
+                <button mat-flat-button (click)="buttonsIconOnly()">Icon-Only</button>
+                <button mat-flat-button (click)="buttonsMixedIcons()">Mixed Icons + Text</button>
+            </div>
+
+            <h3>Form Controls</h3>
+            <div class="button-group">
+                <button mat-flat-button (click)="withCheckbox()">Checkbox + Button</button>
+                <button mat-flat-button (click)="withToggle()">Toggle + Button</button>
+                <button mat-flat-button (click)="withRadioGroup()">Radio Group + Button</button>
+                <button mat-flat-button (click)="withToggleGroup()">Toggle Group + Button</button>
+                <button mat-flat-button (click)="withMixedControls()">All Control Types</button>
+            </div>
+
+            <h3>Queue</h3>
+            <div class="button-group">
+                <button mat-flat-button (click)="banner.dismissAll()">Dismiss All</button>
+            </div>
+            <p class="state">Active: {{ banner.isActive() }} &middot; Pending: {{ banner.pendingCount() }}</p>
+
+            @if (lastResult()) {
+                <div class="result-panel">
+                    <h3>Last Dismiss Result</h3>
+                    <pre>{{ lastResult() | json }}</pre>
+                </div>
+            }
+        </div>
+    `,
+    styles: [
+        `
+            .harness {
+                font-family: Roboto, sans-serif;
+                padding: 1.5rem;
+            }
+            h3 {
+                margin: 1.5rem 0 0.5rem;
+            }
+            h3:first-of-type {
+                margin-top: 0;
+            }
+            .instructions {
+                font-size: 0.875rem;
+                color: #555;
+                background: #f8f9fa;
+                border: 1px solid #e0e0e0;
+                border-radius: 8px;
+                padding: 0.75rem 1rem;
+                margin-bottom: 1.5rem;
+                line-height: 1.6;
+            }
+            .instructions p {
+                margin: 0 0 0.5rem;
+            }
+            .instructions p:last-child,
+            .instructions ul:last-child {
+                margin-bottom: 0;
+            }
+            .instructions ul {
+                margin: 0 0 0.5rem;
+                padding-left: 1.25rem;
+            }
+            .instructions li {
+                margin-bottom: 0.125rem;
+            }
+            .instructions code {
+                background: #eef2ff;
+                color: #4338ca;
+                padding: 0.1em 0.35em;
+                border-radius: 3px;
+                font-size: 0.9em;
+            }
+            .button-group {
+                display: flex;
+                flex-wrap: wrap;
+                gap: 0.5rem;
+            }
+            .state {
+                margin-top: 1rem;
+                font-size: 0.875rem;
+                color: #666;
+            }
+            .result-panel {
+                margin-top: 1rem;
+                background: #f0f4ff;
+                border-left: 3px solid #1565c0;
+                padding: 0.5rem 0.75rem;
+            }
+            .result-panel pre {
+                font-size: 0.8125rem;
+                margin: 0.25rem 0 0;
+                white-space: pre-wrap;
+            }
+        `,
+    ],
+})
+class BannerOverlayActionsHarnessComponent {
+    readonly banner = inject(TbxMatBannerService);
+
+    readonly verticalPosition = input<VerticalPosition>('top');
+    readonly enterExitAnimation = input<EnterExitAnimation>('none');
+    readonly iconSize = input<IconSize>('standard');
+    readonly iconAnimation = input<IconAnimation>('none');
+
+    readonly lastResult = signal<TbxMatBannerResult | null>(null);
+
+    constructor() {
+        // Inject icon size CSS at document level (overlay banners render outside
+        // the component tree via CDK portal).
+        const SIZE_STYLE_ID = 'tbx-banner-story-icon-size';
+        const SIZE_MAP: Record<IconSize, string> = {
+            standard: '',
+            medium: '2rem',
+            large: '3rem',
+        };
+
+        effect(() => {
+            const size = SIZE_MAP[this.iconSize()];
+            document.getElementById(SIZE_STYLE_ID)?.remove();
+            if (!size) return;
+            const style = document.createElement('style');
+            style.id = SIZE_STYLE_ID;
+            style.textContent = `html { --tbx-mat-banner-icon-size: ${size}; }`;
+            document.head.appendChild(style);
+        });
+
+        // Icon animation (state-transition / pulse) injected at document level.
+        const ANIM_STYLE_ID = 'tbx-banner-story-icon-animation';
+
+        const STATE_CSS = `
+      @keyframes tbx-banner-icon-fill {
+        from { font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 24; }
+        to   { font-variation-settings: 'FILL' 1, 'wght' 400, 'GRAD' 0, 'opsz' 24; }
+      }
+      .material-symbols-rounded {
+        animation: tbx-banner-icon-fill 0.3s ease-in-out 0.15s forwards;
+        font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 24;
+      }
+    `;
+
+        const PULSE_CSS = `
+      @keyframes tbx-banner-icon-pulse {
+        from { font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 24; }
+        to   { font-variation-settings: 'FILL' 1, 'wght' 400, 'GRAD' 0, 'opsz' 24; }
+      }
+      .tbx-mat-banner-icon {
+        animation: tbx-banner-icon-pulse 1s ease-in-out infinite alternate;
+        font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 24;
+      }
+    `;
+
+        effect(() => {
+            const mode = this.iconAnimation();
+            document.getElementById(ANIM_STYLE_ID)?.remove();
+            if (mode === 'none') return;
+            const style = document.createElement('style');
+            style.id = ANIM_STYLE_ID;
+            style.textContent = mode === 'state-transition' ? STATE_CSS : PULSE_CSS;
+            document.head.appendChild(style);
+        });
+    }
+
+    private show(severity: Severity, message: string, actionsGroup: TbxMatBannerActionsGroupControl[]): void {
+        const method = this.banner[severity as keyof TbxMatBannerService] as (msg: string, args?: object) => { result: Promise<TbxMatBannerResult> };
+        const ref = method.call(this.banner, message, {
+            actionsGroup,
+            verticalPosition: this.verticalPosition(),
+            animation: this.mapAnimation(),
+        });
+        ref.result.then((result: TbxMatBannerResult) => this.lastResult.set(result));
+    }
+
+    private mapAnimation(): TbxMatBannerAnimation {
+        switch (this.enterExitAnimation()) {
+            case 'slide':
+                return TbxMatBannerAnimation.Slide;
+            case 'fade':
+                return TbxMatBannerAnimation.Fade;
+            default:
+                return TbxMatBannerAnimation.None;
+        }
+    }
+
+    // ── Button Appearances ─────────────────────────────────────────────────────
+
+    buttonsText(): void {
+        this.show('warning', 'Unsaved changes will be lost.', [
+            { type: 'button', key: 'discard', label: 'Discard' },
+            { type: 'button', key: 'save', label: 'Save' },
+        ]);
+    }
+
+    buttonsFilled(): void {
+        this.show('information', 'A new version is available.', [
+            { type: 'button', key: 'later', label: 'Later', appearance: 'filled' },
+            { type: 'button', key: 'update', label: 'Update Now', appearance: 'filled' },
+        ]);
+    }
+
+    buttonsTonal(): void {
+        this.show('error', 'Connection lost. Retrying...', [
+            { type: 'button', key: 'cancel', label: 'Cancel', appearance: 'tonal' },
+            { type: 'button', key: 'retry', label: 'Retry', appearance: 'tonal' },
+        ]);
+    }
+
+    buttonsOutlined(): void {
+        this.show('warning', 'Your trial expires in 3 days.', [
+            { type: 'button', key: 'dismiss', label: 'Dismiss', appearance: 'outlined' },
+            { type: 'button', key: 'upgrade', label: 'Upgrade', appearance: 'outlined' },
+        ]);
+    }
+
+    buttonsMixed(): void {
+        this.show('error', 'Upload failed for 2 of 10 files.', [
+            { type: 'button', key: 'ignore', label: 'Ignore' },
+            { type: 'button', key: 'details', label: 'View Details', appearance: 'outlined' },
+            { type: 'button', key: 'retry', label: 'Retry', appearance: 'filled' },
+        ]);
+    }
+
+    // ── Buttons with Icons ─────────────────────────────────────────────────────
+
+    buttonsLeadingIcons(): void {
+        this.show('success', 'Changes saved to draft.', [
+            {
+                type: 'button',
+                key: 'undo',
+                label: 'Undo',
+                icon: 'undo',
+                appearance: 'outlined',
+                actionIconResolverService: fontIconResolver,
+            },
+            {
+                type: 'button',
+                key: 'publish',
+                label: 'Publish',
+                icon: 'publish',
+                appearance: 'filled',
+                actionIconResolverService: fontIconResolver,
+            },
+        ]);
+    }
+
+    buttonsTrailingIcons(): void {
+        this.show('success', 'Export ready for download.', [
+            { type: 'button', key: 'dismiss', label: 'Dismiss' },
+            {
+                type: 'button',
+                key: 'download',
+                label: 'Download',
+                icon: 'download',
+                iconPosition: 'after',
+                appearance: 'filled',
+                actionIconResolverService: fontIconResolver,
+            },
+        ]);
+    }
+
+    buttonsIconOnly(): void {
+        this.show('default', '3 items selected.', [
+            {
+                type: 'button',
+                key: 'delete',
+                label: 'Delete',
+                icon: 'delete',
+                appearance: 'icon',
+                actionIconResolverService: fontIconResolver,
+            },
+            {
+                type: 'button',
+                key: 'archive',
+                label: 'Archive',
+                icon: 'archive',
+                appearance: 'icon',
+                actionIconResolverService: fontIconResolver,
+            },
+            {
+                type: 'button',
+                key: 'share',
+                label: 'Share',
+                icon: 'share',
+                appearance: 'icon',
+                actionIconResolverService: fontIconResolver,
+            },
+        ]);
+    }
+
+    buttonsMixedIcons(): void {
+        this.show('warning', 'Upload complete with warnings.', [
+            {
+                type: 'button',
+                key: 'details',
+                label: 'View Details',
+                icon: 'info',
+                appearance: 'outlined',
+                actionIconResolverService: fontIconResolver,
+            },
+            {
+                type: 'button',
+                key: 'retry',
+                label: 'Retry',
+                icon: 'refresh',
+                appearance: 'tonal',
+                actionIconResolverService: fontIconResolver,
+            },
+            { type: 'button', key: 'dismiss', label: 'Dismiss' },
+        ]);
+    }
+
+    // ── Form Controls ──────────────────────────────────────────────────────────
+
+    withCheckbox(): void {
+        this.show('information', 'Cookies are required for this site.', [
+            {
+                type: 'checkbox',
+                key: 'dontShowAgain',
+                label: "Don't show again",
+                defaultValue: false,
+            },
+            { type: 'button', key: 'accept', label: 'Accept', appearance: 'filled' },
+        ]);
+    }
+
+    withToggle(): void {
+        this.show('default', 'Auto-save is disabled.', [
+            { type: 'toggle', key: 'autoSave', label: 'Enable auto-save', defaultValue: false },
+            { type: 'button', key: 'confirm', label: 'Confirm', appearance: 'filled' },
+        ]);
+    }
+
+    withRadioGroup(): void {
+        this.show('help', 'Choose export format before proceeding.', [
+            {
+                type: 'radio-group',
+                key: 'format',
+                options: [
+                    { label: 'JSON', value: 'json' },
+                    { label: 'CSV', value: 'csv' },
+                    { label: 'XML', value: 'xml' },
+                ],
+                defaultValue: 'json',
+            },
+            { type: 'button', key: 'export', label: 'Export', appearance: 'filled' },
+        ]);
+    }
+
+    withToggleGroup(): void {
+        this.show('help', 'Select notification channels.', [
+            {
+                type: 'toggle-group',
+                key: 'channels',
+                multiple: true,
+                options: [
+                    { label: 'Email', value: 'email' },
+                    { label: 'SMS', value: 'sms' },
+                    { label: 'Push', value: 'push' },
+                ],
+                defaultValue: ['email'],
+            },
+            { type: 'button', key: 'save', label: 'Save', appearance: 'filled' },
+        ]);
+    }
+
+    withMixedControls(): void {
+        this.show('information', 'Configure update preferences.', [
+            {
+                type: 'checkbox',
+                key: 'autoUpdate',
+                label: 'Auto-update',
+                defaultValue: true,
+            },
+            {
+                type: 'radio-group',
+                key: 'channel',
+                options: [
+                    { label: 'Stable', value: 'stable' },
+                    { label: 'Beta', value: 'beta' },
+                ],
+                defaultValue: 'stable',
+            },
+            { type: 'button', key: 'cancel', label: 'Cancel' },
+            { type: 'button', key: 'apply', label: 'Apply', appearance: 'filled' },
+        ]);
+    }
+}
+
+const meta: Meta<BannerOverlayActionsHarnessComponent> = {
+    title: 'Banners',
+    tags: ['banners'],
+    component: BannerOverlayActionsHarnessComponent,
+    decorators: [moduleMetadata({ imports: [BannerOverlayActionsHarnessComponent] })],
+    argTypes: {
+        verticalPosition: {
+            name: 'Position',
+            control: 'select',
+            options: ['top', 'bottom'],
+            description: 'Vertical position of the overlay banner',
+        },
+        enterExitAnimation: {
+            name: 'Enter/Exit Animation',
+            control: 'select',
+            options: ['none', 'slide', 'fade'],
+            description: 'Enter and exit animation mode',
+        },
+        iconSize: {
+            name: 'Icon Size',
+            control: 'select',
+            options: ['standard', 'medium', 'large'],
+            description: 'Severity icon size',
+        },
+        iconAnimation: {
+            name: 'Icon Animation',
+            control: 'select',
+            options: ['none', 'state-transition', 'pulse'],
+            description: 'Icon fill animation',
+        },
+    },
+};
+
+export default meta;
+type Story = StoryObj<BannerOverlayActionsHarnessComponent>;
+
+export const OverlaysActions: Story = {
+    name: 'Overlays + Actions',
+    args: {
+        verticalPosition: 'top',
+        enterExitAnimation: 'none',
+        iconSize: 'standard',
+        iconAnimation: 'none',
+    },
+};

--- a/src/stories/banners/banner-overlay.stories.ts
+++ b/src/stories/banners/banner-overlay.stories.ts
@@ -1,0 +1,263 @@
+import { Component, effect, inject, input } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import type { Meta, StoryObj } from '@storybook/angular';
+import { moduleMetadata } from '@storybook/angular';
+import { TbxMatBannerAnimation, TbxMatBannerService } from '../../index';
+
+type VerticalPosition = 'top' | 'bottom';
+type EnterExitAnimation = 'none' | 'slide' | 'fade';
+type IconSize = 'standard' | 'medium' | 'large';
+type IconAnimation = 'none' | 'state-transition' | 'pulse';
+
+@Component({
+    selector: 'tbx-banner-overlay-harness',
+    imports: [MatButtonModule],
+    template: `
+        <div class="harness">
+            <div class="instructions">
+                <p><strong>Overlay banners</strong> display pinned at the top or bottom of the viewport via <a href="https://material.angular.dev/cdk/overlay/api" target="_blank" rel="noopener">CDK Overlay</a>. The lifecycle is managed by <code>TbxMatBannerService</code>: call <code>banner.success(&hellip;)</code>, <code>banner.error(&hellip;)</code>, etc. and the service creates the overlay, queues the banner if another is already visible, and resolves a promise when dismissed.</p>
+                <p>The queue is FIFO and only one banner shows at a time — "Fire 6 Queued" sends six in sequence so you can watch them advance. "Dismiss All" empties the queue and closes the active banner. The live state below shows <code>isActive()</code> and <code>pendingCount()</code> signals from the service.</p>
+                <p>Use the <strong>Controls</strong> panel to try all combinations of:</p>
+                <ul>
+                    <li><strong>Position</strong> — top (default) or bottom of the viewport</li>
+                    <li><strong>Enter/Exit Animation</strong> — none, slide (from the edge), or fade</li>
+                    <li><strong>Icon Size</strong> — standard / medium / large severity icon</li>
+                    <li><strong>Icon Animation</strong> — none, state-transition (fill-in on enter), or pulse</li>
+                </ul>
+            </div>
+
+            <h3>Severity Levels</h3>
+            <div class="button-group">
+                <button mat-flat-button (click)="fire('default')">Default</button>
+                <button mat-flat-button (click)="fire('success')">Success</button>
+                <button mat-flat-button (click)="fire('error')">Error</button>
+                <button mat-flat-button (click)="fire('warning')">Warning</button>
+                <button mat-flat-button (click)="fire('information')">Information</button>
+                <button mat-flat-button (click)="fire('help')">Help</button>
+            </div>
+
+            <h3>Queue Demo</h3>
+            <p class="theme-note">Banners display in FIFO order — fire a queue of six and they appear one after another.</p>
+            <div class="button-group">
+                <button mat-flat-button (click)="queueAll()">Fire 6 Queued</button>
+                <button mat-flat-button (click)="banner.dismissAll()">Dismiss All</button>
+            </div>
+            <p class="state">Active: {{ banner.isActive() }} &middot; Pending: {{ banner.pendingCount() }}</p>
+        </div>
+    `,
+    styles: [
+        `
+            .harness {
+                font-family: Roboto, sans-serif;
+                padding: 1.5rem;
+            }
+            h3 {
+                margin: 1.5rem 0 0.5rem;
+            }
+            h3:first-of-type {
+                margin-top: 0;
+            }
+            .instructions {
+                font-size: 0.875rem;
+                color: #555;
+                background: #f8f9fa;
+                border: 1px solid #e0e0e0;
+                border-radius: 8px;
+                padding: 0.75rem 1rem;
+                margin-bottom: 1.5rem;
+                line-height: 1.6;
+            }
+            .instructions p {
+                margin: 0 0 0.5rem;
+            }
+            .instructions p:last-child,
+            .instructions ul:last-child {
+                margin-bottom: 0;
+            }
+            .instructions ul {
+                margin: 0;
+                padding-left: 1.25rem;
+            }
+            .instructions li {
+                margin-bottom: 0.125rem;
+            }
+            .instructions code {
+                background: #eef2ff;
+                color: #4338ca;
+                padding: 0.1em 0.35em;
+                border-radius: 3px;
+                font-size: 0.9em;
+            }
+            .instructions a {
+                color: #4338ca;
+            }
+            .button-group {
+                display: flex;
+                flex-wrap: wrap;
+                gap: 0.5rem;
+            }
+            .state {
+                margin-top: 1rem;
+                font-size: 0.875rem;
+                color: #666;
+            }
+            .theme-note {
+                font-size: 0.8125rem;
+                color: #888;
+                border-left: 3px solid #ddd;
+                padding: 0.25rem 0.75rem;
+                margin: 0 0 1rem;
+            }
+        `,
+    ],
+})
+class BannerOverlayHarnessComponent {
+    readonly banner = inject(TbxMatBannerService);
+
+    readonly verticalPosition = input<VerticalPosition>('top');
+    readonly enterExitAnimation = input<EnterExitAnimation>('none');
+    readonly iconSize = input<IconSize>('standard');
+    readonly iconAnimation = input<IconAnimation>('none');
+
+    private readonly messages: Record<string, string> = {
+        default: 'This is a default banner with no severity styling.',
+        success: 'Operation completed successfully.',
+        error: 'Something went wrong. Please try again.',
+        warning: 'Your session will expire in 5 minutes.',
+        information: 'A new version is available.',
+        help: 'Click the + button to add a new item.',
+    };
+
+    constructor() {
+        // Inject icon size CSS custom property at document level so it reaches
+        // overlay banners (which render outside the component tree via CDK portal).
+        const SIZE_STYLE_ID = 'tbx-banner-story-icon-size';
+        const SIZE_MAP: Record<IconSize, string> = {
+            standard: '',
+            medium: '2rem',
+            large: '3rem',
+        };
+
+        effect(() => {
+            const size = SIZE_MAP[this.iconSize()];
+            document.getElementById(SIZE_STYLE_ID)?.remove();
+            if (!size) return;
+            const style = document.createElement('style');
+            style.id = SIZE_STYLE_ID;
+            style.textContent = `html { --tbx-mat-banner-icon-size: ${size}; }`;
+            document.head.appendChild(style);
+        });
+
+        // Inject icon animation CSS at document level (same reason as above).
+        const ANIM_STYLE_ID = 'tbx-banner-story-icon-animation';
+
+        const STATE_CSS = `
+      @keyframes tbx-banner-icon-fill {
+        from { font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 24; }
+        to   { font-variation-settings: 'FILL' 1, 'wght' 400, 'GRAD' 0, 'opsz' 24; }
+      }
+      .material-symbols-rounded {
+        animation: tbx-banner-icon-fill 0.3s ease-in-out 0.15s forwards;
+        font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 24;
+      }
+    `;
+
+        const PULSE_CSS = `
+      @keyframes tbx-banner-icon-pulse {
+        from { font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 24; }
+        to   { font-variation-settings: 'FILL' 1, 'wght' 400, 'GRAD' 0, 'opsz' 24; }
+      }
+      .tbx-mat-banner-icon {
+        animation: tbx-banner-icon-pulse 1s ease-in-out infinite alternate;
+        font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 24;
+      }
+    `;
+
+        effect(() => {
+            const mode = this.iconAnimation();
+            document.getElementById(ANIM_STYLE_ID)?.remove();
+            if (mode === 'none') return;
+            const style = document.createElement('style');
+            style.id = ANIM_STYLE_ID;
+            style.textContent = mode === 'state-transition' ? STATE_CSS : PULSE_CSS;
+            document.head.appendChild(style);
+        });
+    }
+
+    fire(level: string): void {
+        const method = this.banner[level as keyof TbxMatBannerService] as (msg: string, args?: object) => void;
+        method.call(this.banner, this.messages[level], {
+            verticalPosition: this.verticalPosition(),
+            animation: this.mapAnimation(),
+        });
+    }
+
+    queueAll(): void {
+        const args = {
+            verticalPosition: this.verticalPosition(),
+            animation: this.mapAnimation(),
+        };
+        this.banner.default('Step 1: This is a default banner.', args);
+        this.banner.success('Step 2: Operation completed successfully.', args);
+        this.banner.error('Step 3: Something went wrong.', args);
+        this.banner.warning('Step 4: Review needed.', args);
+        this.banner.information('Step 5: A new version is available.', args);
+        this.banner.help('Step 6: Click the + button to add a new item.', args);
+    }
+
+    private mapAnimation(): TbxMatBannerAnimation {
+        switch (this.enterExitAnimation()) {
+            case 'slide':
+                return TbxMatBannerAnimation.Slide;
+            case 'fade':
+                return TbxMatBannerAnimation.Fade;
+            default:
+                return TbxMatBannerAnimation.None;
+        }
+    }
+}
+
+const meta: Meta<BannerOverlayHarnessComponent> = {
+    title: 'Banners',
+    tags: ['banners'],
+    component: BannerOverlayHarnessComponent,
+    decorators: [moduleMetadata({ imports: [BannerOverlayHarnessComponent] })],
+    argTypes: {
+        verticalPosition: {
+            name: 'Position',
+            control: 'select',
+            options: ['top', 'bottom'],
+            description: 'Vertical position of the overlay banner',
+        },
+        enterExitAnimation: {
+            name: 'Enter/Exit Animation',
+            control: 'select',
+            options: ['none', 'slide', 'fade'],
+            description: 'Enter and exit animation mode',
+        },
+        iconSize: {
+            name: 'Icon Size',
+            control: 'select',
+            options: ['standard', 'medium', 'large'],
+            description: 'Severity icon size',
+        },
+        iconAnimation: {
+            name: 'Icon Animation',
+            control: 'select',
+            options: ['none', 'state-transition', 'pulse'],
+            description: 'Icon fill animation',
+        },
+    },
+};
+
+export default meta;
+type Story = StoryObj<BannerOverlayHarnessComponent>;
+
+export const Overlays: Story = {
+    args: {
+        verticalPosition: 'top',
+        enterExitAnimation: 'none',
+        iconSize: 'standard',
+        iconAnimation: 'none',
+    },
+};


### PR DESCRIPTION
## Summary

Carries the docs-pipeline work from \`dev\` to \`main\`.

Includes:
- #68 — docs(readme): overhaul README, add docs/ manifests, split Storybook dev/docs
- #69 — feat(build): ship docs manifests in the published tarball
- #70 — ci(pages): add thin caller for the reusable Docs Deploy workflow

## What happens after merge

- Release Please will open or update its release PR reflecting the \`feat\` commits.
- On release publish, \`docs/*.md\` and \`docs/*.yml\` ship inside the npm tarball.
- The Docs Deploy caller fires on this merge to \`main\`, publishing the docs Storybook to https://teqbench.github.io/tbx-mat-banners/.

🤖 Generated with [Claude Code](https://claude.com/claude-code)