### PR TITLE
fix(storybook): restore narrative story sort in docs sidebar

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -36,8 +36,18 @@ const preview: Preview = {
     ],
     parameters: {
         options: {
-            storySort: {
-                order: ['Banners', ['Overlay']],
+            // Custom sort so stories within the Banners group appear in the
+            // intended narrative order (simple → complex → customization)
+            // rather than the default alphabetical order. Mirrors the sort
+            // used by teqbench.website's embedded Storybook.
+            storySort: (a, b) => {
+                const ORDER = ['banners--inline', 'banners--overlays', 'banners--overlays-actions', 'banners--custom'];
+                const aIdx = ORDER.indexOf(a.id);
+                const bIdx = ORDER.indexOf(b.id);
+                if (aIdx === -1 && bIdx === -1) return a.id.localeCompare(b.id);
+                if (aIdx === -1) return 1;
+                if (bIdx === -1) return -1;
+                return aIdx - bIdx;
             },
         },
         controls: {


### PR DESCRIPTION
## Summary

Restores the explicit narrative sort order for docs stories (Inline → Overlays → Overlays + Actions → Custom), matching the order used by teqbench.website's embedded Storybook. The alphabetical default that shipped with #73 ordered them as Custom → Inline → Overlays → Overlays + Actions, which is not the intended reading sequence.

Stories outside the explicit ORDER list fall back to alphabetical, so dev harness stories are unaffected.

## Test plan

- [x] \`npm run build-storybook:docs\` — sidebar order verified via headless inspection: \`banners--inline, banners--overlays, banners--overlays-actions, banners--custom\`
- [ ] After release to \`main\`, confirm the Pages deploy renders the sidebar in the same order

🤖 Generated with [Claude Code](https://claude.com/claude-code)