### PR TITLE
release: restore narrative story sort in docs sidebar

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -36,8 +36,18 @@ const preview: Preview = {
     ],
     parameters: {
         options: {
-            storySort: {
-                order: ['Banners', ['Overlay']],
+            // Custom sort so stories within the Banners group appear in the
+            // intended narrative order (simple → complex → customization)
+            // rather than the default alphabetical order. Mirrors the sort
+            // used by teqbench.website's embedded Storybook.
+            storySort: (a, b) => {
+                const ORDER = ['banners--inline', 'banners--overlays', 'banners--overlays-actions', 'banners--custom'];
+                const aIdx = ORDER.indexOf(a.id);
+                const bIdx = ORDER.indexOf(b.id);
+                if (aIdx === -1 && bIdx === -1) return a.id.localeCompare(b.id);
+                if (aIdx === -1) return 1;
+                if (bIdx === -1) return -1;
+                return aIdx - bIdx;
             },
         },
         controls: {


### PR DESCRIPTION
## Summary

Carries #76 from \`dev\` to \`main\`. Restores the intended Inline → Overlays → Overlays + Actions → Custom order in the docs Storybook sidebar.

## After merge

The Docs Deploy workflow refires automatically and redeploys the updated docs Storybook to https://teqbench.github.io/tbx-mat-banners/.

🤖 Generated with [Claude Code](https://claude.com/claude-code)