### PR TITLE
docs(tsdoc): demote in-@remarks subheadings from ### to ####

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,6 +91,10 @@ Add `@order` to any member where alphabetical sorting within its group produces 
 - `id` should appear before `createdAt` and `updatedAt` — give `id` `@order 1`.
 - Lifecycle-related properties should appear in logical sequence — use `@order` to enforce creation-before-update ordering.
 
+### Subheadings inside tag blocks
+
+Markdown subheadings authored inside `@remarks`, `@usage`, or `@example` start at `####` (H4). The downstream docs renderer (teqbench.website) wraps each tag section with its own `<h4>` label ("Remarks", "When to use", "Example"), so any `###` subheadings in the authored content render _larger_ than the tag's own label and appear as if they were sibling top-level exports rather than nested subsections. Using `####` keeps subheadings visually below their parent label.
+
 ### Comment Structure
 
 Top-level exports:

--- a/src/components/banner.component.ts
+++ b/src/components/banner.component.ts
@@ -41,7 +41,7 @@ interface ResolvedIcon {
  * Renders a severity-styled banner with an optional severity icon, message,
  * actions group (buttons and form controls), and close button.
  *
- * ### Display Modes
+ * #### Display Modes
  *
  * - **Overlay mode:** Created by {@link TbxMatBannerService} via
  *   {@link https://material.angular.dev/cdk/overlay/api | CDK Overlay}.
@@ -51,14 +51,14 @@ interface ResolvedIcon {
  * - **Inline mode:** Placed directly in a consumer's template.
  *   Receives data through signal inputs and emits dismiss events via outputs.
  *
- * ### Template element order
+ * #### Template element order
  *
  * severity icon | message | actions group | close button
  *
  * All elements are optional except the message. The actions group and
  * close button render in the actions slot.
  *
- * ### Actions group rendering
+ * #### Actions group rendering
  *
  * Controls render in array order via `@switch (control.type)`. Form control
  * values are tracked internally via writable signals initialized from each

--- a/src/models/banner-provider-config.model.ts
+++ b/src/models/banner-provider-config.model.ts
@@ -11,7 +11,7 @@ import { type TbxMatBannerAnimation } from '../enums/banner-animation.enum';
  * in `app.config.ts`. Groups all banner icon customization into a single
  * provider entry.
  *
- * ### Properties
+ * #### Properties
  *
  * - **`severityIconResolverService`** — resolves severity levels to icon identifiers. Must
  *   implement `TbxMatIconResolver` from `@teqbench/tbx-mat-icons`. Use

--- a/src/models/banner-ref.model.ts
+++ b/src/models/banner-ref.model.ts
@@ -15,7 +15,7 @@ import { type TbxMatBannerResult } from './banner-result.model';
  *   the button that triggered dismissal (if applicable), and the
  *   `actionsGroupValues` record when the banner is dismissed.
  *
- * ### Fire-and-Forget Usage
+ * #### Fire-and-Forget Usage
  *
  * Consumers who do not need the dismiss result should
  * prefix the call with `void` to suppress unhandled-promise lint warnings:

--- a/src/services/banner-close-font-icon.service.ts
+++ b/src/services/banner-close-font-icon.service.ts
@@ -16,7 +16,7 @@ import { TbxMatFontIconService } from '@teqbench/tbx-mat-icons';
  * from `@teqbench/tbx-mat-icons` and provide it via
  * {@link TbxMatBannerProviderConfig.closeIconResolverService}.
  *
- * ### fontSet resolution
+ * #### fontSet resolution
  *
  * The fontSet is resolved by `TbxMatFontIconService`'s fallback chain:
  *

--- a/src/services/banner-severity-font-icon.service.ts
+++ b/src/services/banner-severity-font-icon.service.ts
@@ -10,7 +10,7 @@ import { TbxMatSeverityFontIconService, TbxMatSeverityLevel } from '@teqbench/tb
  * for each severity level. The inherited `resolve()` and severity
  * methods (`success()`, `error()`, etc.) work via the registered mappings.
  *
- * ### fontSet resolution
+ * #### fontSet resolution
  *
  * The fontSet is resolved by `TbxMatFontIconService`'s fallback chain:
  *


### PR DESCRIPTION
## Summary

Demotes \`###\` subheadings authored inside \`@remarks\`, \`@usage\`, or \`@example\` TSDoc blocks to \`####\` so they nest correctly under the tag label the docs renderer wraps around each section.

## Why

Discovered during teqbench.website tab review. The website wraps each TSDoc tag section in its own \`<h4>\` label ("Remarks", "When to use", "Example"). Authored \`###\` subheadings therefore render as \`<h3>\` — one level *larger* than the tag label — and read as sibling top-level exports. On the Overview tab, entries like "Display Modes" inside \`TbxMatBannerComponent\`'s \`@remarks\` looked like separate Components at the same level as the component itself. On the API tab's detail view the same subheadings outranked the "Remarks" wrapper.

## Changes

- Seven \`###\` → \`####\` edits across five files (banner.component.ts, banner-provider-config.model.ts, banner-ref.model.ts, banner-severity-font-icon.service.ts, banner-close-font-icon.service.ts).
- New "Subheadings inside tag blocks" rule in \`CLAUDE.md\` so future TSDoc contributions follow the same convention; also serves as the reference for sibling packages as they adopt the docs pipeline.

## Test plan

- [x] \`npm run lint\`, \`npm run typecheck\`, \`npm run format:check\` — clean
- [x] \`npm test\` — 121 tests pass
- [ ] After release to main + website rebuild, verify Overview tab "Components" section no longer shows "Display Modes" / "Template element order" / "Actions group rendering" as sibling H3s to TbxMatBannerComponent
- [ ] Verify API tab detail view for TbxMatBannerComponent shows those subheadings nested under the "Remarks" H4

🤖 Generated with [Claude Code](https://claude.com/claude-code)