### PR TITLE
fix(styles): decouple close-icon opacity from action-button opacity

### DIFF
--- a/src/styles/_tbx-mat-banners.scss
+++ b/src/styles/_tbx-mat-banners.scss
@@ -20,23 +20,35 @@ html {
     @include severity.tbx-mat-severity-theme('tbx-mat-banner');
 }
 
-/* ━━━ Action Button Opacity Tokens ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+/* ━━━ Opacity Tokens━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  *
- * Centralized opacity values used by action button variants within severity
- * panels. Defined once here so downstream consumers can override them
- * without touching individual severity classes.
+ * Two independent concerns:
+ *
+ * 1. Action button opacities — alias from `--tbx-mat-banner-action-text-opacity`
+ *    (0.8). Control how opaque action button labels and icons render
+ *    relative to the panel's `$text` color. The slight transparency
+ *    differentiates action buttons from the message text. Tonal container
+ *    has its own opacity (0.55) to read as a muted surface; filled
+ *    container is opaque (`$text` at 100%) to read as a true filled button
+ *    against the colored panel.
+ *
+ * 2. Close icon opacity — independent primitive (0.8). The close icon is a
+ *    structural header element, not an action button, so it does not follow
+ *    the action-button opacity stack.
+ *
+ * Defined at `:root` so consumers can override globally without touching
+ * individual severity classes.
  * ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ */
 
 html {
     --tbx-mat-banner-action-text-opacity: 0.8;
-
-    --tbx-mat-banner-action-filled-container-opacity: var(--tbx-mat-banner-action-text-opacity);
     --tbx-mat-banner-action-tonal-container-opacity: 0.55;
 
     --tbx-mat-banner-action-outlined-opacity: var(--tbx-mat-banner-action-text-opacity);
     --tbx-mat-banner-action-elevated-opacity: var(--tbx-mat-banner-action-text-opacity);
     --tbx-mat-banner-action-icon-opacity: var(--tbx-mat-banner-action-text-opacity);
-    --tbx-mat-banner-close-icon-opacity: var(--tbx-mat-banner-action-text-opacity);
+
+    --tbx-mat-banner-close-icon-opacity: 0.8;
 
     --tbx-mat-banner-action-filled-hover-state-layer-opacity: 0.3;
     --tbx-mat-banner-action-tonal-hover-state-layer-opacity: var(--tbx-mat-banner-action-filled-hover-state-layer-opacity);
@@ -214,7 +226,7 @@ html {
     --mat-button-text-ripple-color: color-mix(in srgb, #{$text} calc(var(--mat-sys-pressed-state-layer-opacity) * 100%), transparent);
 
     /* ── Filled button ── */
-    --mat-button-filled-container-color: color-mix(in srgb, #{$text} calc(var(--tbx-mat-banner-action-filled-container-opacity) * 100%), transparent);
+    --mat-button-filled-container-color: #{$text};
     --mat-button-filled-label-text-color: #{$bg};
     --mat-button-filled-state-layer-color: #{$bg};
     --mat-button-filled-hover-state-layer-opacity: var(--tbx-mat-banner-action-filled-hover-state-layer-opacity);


### PR DESCRIPTION
## Summary

Promote the close-icon / action-button opacity decoupling work from `dev` to `main`.

Single commit in this release: `fix(styles): decouple close-icon opacity from action-button opacity`. Patch bump expected from Release Please.

See the dev PR for the full breakdown — teqbench/tbx-mat-banners#157.

Refs teqbench/tbx-mat-dialogs#98 (cross-package epic)

## Test plan

- [x] All checks passed in the dev PR (lint, typecheck, tests, format, build)
- [ ] Release Please opens its versioned release PR after this merges
- [ ] Verify the published version on the next Release Please merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
