### PR TITLE
fix(ci): pin reusable workflows to @v2.6.0 + bump @teqbench peerDeps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   ci:
-    uses: teqbench/.github/.github/workflows/ci.yml@main
+    uses: teqbench/.github/.github/workflows/ci.yml@v2.6.0
     with:
       gist-id: ${{ vars.GIST_ID }}
     secrets: inherit

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -24,5 +24,5 @@ jobs:
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'issues' && contains(github.event.issue.body, '@claude'))
-    uses: teqbench/.github/.github/workflows/claude.yml@main
+    uses: teqbench/.github/.github/workflows/claude.yml@v2.6.0
     secrets: inherit

--- a/.github/workflows/dep-compat-check.yml
+++ b/.github/workflows/dep-compat-check.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   check:
-    uses: teqbench/.github/.github/workflows/dep-compat-check.yml@main
+    uses: teqbench/.github/.github/workflows/dep-compat-check.yml@v2.6.0
     with:
       epic-issue-number: 1
     secrets: inherit

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -13,5 +13,5 @@ concurrency:
 
 jobs:
   docs-deploy:
-    uses: teqbench/.github/.github/workflows/docs-deploy.yml@main
+    uses: teqbench/.github/.github/workflows/docs-deploy.yml@v2.6.0
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,5 +13,5 @@ concurrency:
 
 jobs:
   release:
-    uses: teqbench/.github/.github/workflows/release.yml@main
+    uses: teqbench/.github/.github/workflows/release.yml@v2.6.0
     secrets: inherit

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -13,5 +13,5 @@ concurrency:
 
 jobs:
   sync:
-    uses: teqbench/.github/.github/workflows/sync.yml@main
+    uses: teqbench/.github/.github/workflows/sync.yml@v2.6.0
     secrets: inherit

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,8 +50,8 @@
         "@angular/cdk": ">=21.0.0",
         "@angular/core": ">=21.0.0",
         "@angular/material": ">=21.0.0",
-        "@teqbench/tbx-mat-icons": ">=4.0.0",
-        "@teqbench/tbx-mat-severity-theme": ">=8.0.0",
+        "@teqbench/tbx-mat-icons": ">=4.2.1",
+        "@teqbench/tbx-mat-severity-theme": ">=8.0.3",
         "rxjs": ">=7.0.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
     "@angular/cdk": ">=21.0.0",
     "@angular/core": ">=21.0.0",
     "@angular/material": ">=21.0.0",
-    "@teqbench/tbx-mat-icons": ">=4.0.0",
-    "@teqbench/tbx-mat-severity-theme": ">=8.0.0",
+    "@teqbench/tbx-mat-icons": ">=4.2.1",
+    "@teqbench/tbx-mat-severity-theme": ">=8.0.3",
     "rxjs": ">=7.0.0"
   },
   "devDependenciesPinned": {


### PR DESCRIPTION
Part of #32 (in teqbench/.github), Wave 3

## Summary

Two changes folded into one PR:

1. `fix(ci):` Pins every thin caller in this repo to `teqbench/.github` v2.6.0 (first versioned release of org-wide reusable workflows), replacing prior `@main` / `@<sha>` refs.
2. `fix(deps):` Bumps `@teqbench/tbx-mat-icons` peerDep floor to `>=4.2.1` and `@teqbench/tbx-mat-severity-theme` to `>=8.0.3`, picking up patches released in Waves 1 and 2 of this rollout.

## Why

Tag-based pins read as auditable diffs in PRs, are immutable, and let Renovate auto-PR future bumps. Both commits land as `fix:` so release-please cuts a patch release after the PR carries to main.

## Test plan

- [ ] CI passes against the pinned reusable workflow
- [ ] Once merged via dev → main, release-please proposes a patch bump