### PR TITLE
release: pin reusable workflows to @v2.6.0 + bump @teqbench peerDeps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   ci:
-    uses: teqbench/.github/.github/workflows/ci.yml@main
+    uses: teqbench/.github/.github/workflows/ci.yml@v2.6.0
     with:
       gist-id: ${{ vars.GIST_ID }}
     secrets: inherit

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -24,5 +24,5 @@ jobs:
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'issues' && contains(github.event.issue.body, '@claude'))
-    uses: teqbench/.github/.github/workflows/claude.yml@main
+    uses: teqbench/.github/.github/workflows/claude.yml@v2.6.0
     secrets: inherit

--- a/.github/workflows/dep-compat-check.yml
+++ b/.github/workflows/dep-compat-check.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   check:
-    uses: teqbench/.github/.github/workflows/dep-compat-check.yml@main
+    uses: teqbench/.github/.github/workflows/dep-compat-check.yml@v2.6.0
     with:
       epic-issue-number: 1
     secrets: inherit

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -13,5 +13,5 @@ concurrency:
 
 jobs:
   docs-deploy:
-    uses: teqbench/.github/.github/workflows/docs-deploy.yml@main
+    uses: teqbench/.github/.github/workflows/docs-deploy.yml@v2.6.0
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,5 +13,5 @@ concurrency:
 
 jobs:
   release:
-    uses: teqbench/.github/.github/workflows/release.yml@main
+    uses: teqbench/.github/.github/workflows/release.yml@v2.6.0
     secrets: inherit

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -13,5 +13,5 @@ concurrency:
 
 jobs:
   sync:
-    uses: teqbench/.github/.github/workflows/sync.yml@main
+    uses: teqbench/.github/.github/workflows/sync.yml@v2.6.0
     secrets: inherit

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,8 +50,8 @@
         "@angular/cdk": ">=21.0.0",
         "@angular/core": ">=21.0.0",
         "@angular/material": ">=21.0.0",
-        "@teqbench/tbx-mat-icons": ">=4.0.0",
-        "@teqbench/tbx-mat-severity-theme": ">=8.0.0",
+        "@teqbench/tbx-mat-icons": ">=4.2.1",
+        "@teqbench/tbx-mat-severity-theme": ">=8.0.3",
         "rxjs": ">=7.0.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
     "@angular/cdk": ">=21.0.0",
     "@angular/core": ">=21.0.0",
     "@angular/material": ">=21.0.0",
-    "@teqbench/tbx-mat-icons": ">=4.0.0",
-    "@teqbench/tbx-mat-severity-theme": ">=8.0.0",
+    "@teqbench/tbx-mat-icons": ">=4.2.1",
+    "@teqbench/tbx-mat-severity-theme": ">=8.0.3",
     "rxjs": ">=7.0.0"
   },
   "devDependenciesPinned": {


### PR DESCRIPTION
Carries dev → main:
- `fix(ci):` pin reusable workflows to `teqbench/.github@v2.6.0`
- `fix(deps):` bump `@teqbench/tbx-mat-icons` peerDep floor to `>=4.2.1` and `@teqbench/tbx-mat-severity-theme` to `>=8.0.3`

Once merged, release-please opens a patch-bump release PR for this repo.

Part of #32 (in teqbench/.github), Wave 3

## Test plan

- [ ] After merge, release-please opens a patch-bump release PR
- [ ] Merging that release PR publishes the new version

🤖 Generated with [Claude Code](https://claude.com/claude-code)