### PR TITLE
fix(deps): bump tbx-mat-icons and tbx-mat-severity-theme peerDeps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,8 +50,8 @@
         "@angular/cdk": ">=21.0.0",
         "@angular/core": ">=21.0.0",
         "@angular/material": ">=21.0.0",
-        "@teqbench/tbx-mat-icons": ">=4.2.1",
-        "@teqbench/tbx-mat-severity-theme": ">=8.0.3",
+        "@teqbench/tbx-mat-icons": ">=4.2.2",
+        "@teqbench/tbx-mat-severity-theme": ">=8.0.4",
         "rxjs": ">=7.0.0"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -7051,9 +7051,9 @@
       }
     },
     "node_modules/@teqbench/tbx-mat-icons": {
-      "version": "4.2.0",
-      "resolved": "https://npm.pkg.github.com/download/@teqbench/tbx-mat-icons/4.2.0/bbc9a9013ce2592af6d8b005186b9ddaee237a6e",
-      "integrity": "sha512-JHtE5DSHf1KnowT7AWlkX96OfvB5bk59A8p9LXvTv1FQK+a0AC1CAttC7FaHH7g1Cw6Un+BdYI3o3LXz0mYmPQ==",
+      "version": "4.2.2",
+      "resolved": "https://npm.pkg.github.com/download/@teqbench/tbx-mat-icons/4.2.2/f87d111f8860a8705657accf0ee200401f89707d",
+      "integrity": "sha512-geTlBZd/iDg8na9JyyzYHXEwQzxJVBJx/Y2kKLFD3Mf5OGjnVGPiSEKWRmJ/ZDMZ7njlgAeJ8whY9K0kJqh7bg==",
       "dev": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
@@ -7069,9 +7069,9 @@
       }
     },
     "node_modules/@teqbench/tbx-mat-severity-theme": {
-      "version": "8.0.2",
-      "resolved": "https://npm.pkg.github.com/download/@teqbench/tbx-mat-severity-theme/8.0.2/fa8f91bf2bcd7c0688e9e3ee06d2e4ddd71d72f5",
-      "integrity": "sha512-8vLaaNpt1II61IvdvdObHIosKXY/KYlz+dgP9VEeg5sfAPIXCoEjt+UZ+3gVtgTHb8AaE1LVT9F5/RHSBGNjPg==",
+      "version": "8.0.4",
+      "resolved": "https://npm.pkg.github.com/download/@teqbench/tbx-mat-severity-theme/8.0.4/dbfd011daa2de53e902ae36eec29436ad9414f4c",
+      "integrity": "sha512-J6pIZgQc55aGSASoRrPX5W+BQayI+tVHPwiv5Zcr1ZqNW5MjWMQm7roh0cDOinRLrFzWsH0E2c/Zye3ryJ5y3g==",
       "dev": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
@@ -7084,7 +7084,7 @@
         "@angular/core": "^21.0.0",
         "@angular/material": "^21.0.0",
         "@angular/platform-browser": "^21.0.0",
-        "@teqbench/tbx-mat-icons": "^4.2.0"
+        "@teqbench/tbx-mat-icons": "^4.2.2"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
     "@angular/cdk": ">=21.0.0",
     "@angular/core": ">=21.0.0",
     "@angular/material": ">=21.0.0",
-    "@teqbench/tbx-mat-icons": ">=4.2.1",
-    "@teqbench/tbx-mat-severity-theme": ">=8.0.3",
+    "@teqbench/tbx-mat-icons": ">=4.2.2",
+    "@teqbench/tbx-mat-severity-theme": ">=8.0.4",
     "rxjs": ">=7.0.0"
   },
   "devDependenciesPinned": {


### PR DESCRIPTION
Catches the patches from Wave A (tbx-mat-icons v4.2.2) and Wave B (tbx-mat-severity-theme v8.0.4).

Locally verified: `npm install` resolves to the new patches, `npm run build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)