### PR TITLE
release: pin reusable workflows to @v2.9.3 + bump @teqbench peerDeps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   ci:
-    uses: teqbench/.github/.github/workflows/ci.yml@v2.6.0
+    uses: teqbench/.github/.github/workflows/ci.yml@v2.9.3
     with:
       gist-id: ${{ vars.GIST_ID }}
     secrets: inherit

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -24,5 +24,5 @@ jobs:
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'issues' && contains(github.event.issue.body, '@claude'))
-    uses: teqbench/.github/.github/workflows/claude.yml@v2.6.0
+    uses: teqbench/.github/.github/workflows/claude.yml@v2.9.3
     secrets: inherit

--- a/.github/workflows/dep-compat-check.yml
+++ b/.github/workflows/dep-compat-check.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   check:
-    uses: teqbench/.github/.github/workflows/dep-compat-check.yml@v2.6.0
+    uses: teqbench/.github/.github/workflows/dep-compat-check.yml@v2.9.3
     with:
       epic-issue-number: 1
     secrets: inherit

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -13,5 +13,5 @@ concurrency:
 
 jobs:
   docs-deploy:
-    uses: teqbench/.github/.github/workflows/docs-deploy.yml@v2.6.0
+    uses: teqbench/.github/.github/workflows/docs-deploy.yml@v2.9.3
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,5 +13,5 @@ concurrency:
 
 jobs:
   release:
-    uses: teqbench/.github/.github/workflows/release.yml@v2.6.0
+    uses: teqbench/.github/.github/workflows/release.yml@v2.9.3
     secrets: inherit

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -13,5 +13,5 @@ concurrency:
 
 jobs:
   sync:
-    uses: teqbench/.github/.github/workflows/sync.yml@v2.6.0
+    uses: teqbench/.github/.github/workflows/sync.yml@v2.9.3
     secrets: inherit

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,8 +50,8 @@
         "@angular/cdk": ">=21.0.0",
         "@angular/core": ">=21.0.0",
         "@angular/material": ">=21.0.0",
-        "@teqbench/tbx-mat-icons": ">=4.2.1",
-        "@teqbench/tbx-mat-severity-theme": ">=8.0.3",
+        "@teqbench/tbx-mat-icons": ">=4.2.2",
+        "@teqbench/tbx-mat-severity-theme": ">=8.0.4",
         "rxjs": ">=7.0.0"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -7051,9 +7051,9 @@
       }
     },
     "node_modules/@teqbench/tbx-mat-icons": {
-      "version": "4.2.0",
-      "resolved": "https://npm.pkg.github.com/download/@teqbench/tbx-mat-icons/4.2.0/bbc9a9013ce2592af6d8b005186b9ddaee237a6e",
-      "integrity": "sha512-JHtE5DSHf1KnowT7AWlkX96OfvB5bk59A8p9LXvTv1FQK+a0AC1CAttC7FaHH7g1Cw6Un+BdYI3o3LXz0mYmPQ==",
+      "version": "4.2.2",
+      "resolved": "https://npm.pkg.github.com/download/@teqbench/tbx-mat-icons/4.2.2/f87d111f8860a8705657accf0ee200401f89707d",
+      "integrity": "sha512-geTlBZd/iDg8na9JyyzYHXEwQzxJVBJx/Y2kKLFD3Mf5OGjnVGPiSEKWRmJ/ZDMZ7njlgAeJ8whY9K0kJqh7bg==",
       "dev": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
@@ -7069,9 +7069,9 @@
       }
     },
     "node_modules/@teqbench/tbx-mat-severity-theme": {
-      "version": "8.0.2",
-      "resolved": "https://npm.pkg.github.com/download/@teqbench/tbx-mat-severity-theme/8.0.2/fa8f91bf2bcd7c0688e9e3ee06d2e4ddd71d72f5",
-      "integrity": "sha512-8vLaaNpt1II61IvdvdObHIosKXY/KYlz+dgP9VEeg5sfAPIXCoEjt+UZ+3gVtgTHb8AaE1LVT9F5/RHSBGNjPg==",
+      "version": "8.0.4",
+      "resolved": "https://npm.pkg.github.com/download/@teqbench/tbx-mat-severity-theme/8.0.4/dbfd011daa2de53e902ae36eec29436ad9414f4c",
+      "integrity": "sha512-J6pIZgQc55aGSASoRrPX5W+BQayI+tVHPwiv5Zcr1ZqNW5MjWMQm7roh0cDOinRLrFzWsH0E2c/Zye3ryJ5y3g==",
       "dev": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
@@ -7084,7 +7084,7 @@
         "@angular/core": "^21.0.0",
         "@angular/material": "^21.0.0",
         "@angular/platform-browser": "^21.0.0",
-        "@teqbench/tbx-mat-icons": "^4.2.0"
+        "@teqbench/tbx-mat-icons": "^4.2.2"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
     "@angular/cdk": ">=21.0.0",
     "@angular/core": ">=21.0.0",
     "@angular/material": ">=21.0.0",
-    "@teqbench/tbx-mat-icons": ">=4.2.1",
-    "@teqbench/tbx-mat-severity-theme": ">=8.0.3",
+    "@teqbench/tbx-mat-icons": ">=4.2.2",
+    "@teqbench/tbx-mat-severity-theme": ">=8.0.4",
     "rxjs": ">=7.0.0"
   },
   "devDependenciesPinned": {


### PR DESCRIPTION
Carries dev → main:
- `fix(ci):` pin reusable workflows to teqbench/.github@v2.9.3
- `fix(deps):` bump tbx-mat-icons (>=4.2.2) and tbx-mat-severity-theme (>=8.0.4) peerDeps
- `chore(deps):` lockfile resolves to the new patches

After merge, release-please cuts a patch release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)