### PR TITLE
fix(changelog): strip broken at-mention autolinks from history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Bug Fixes
 
-* **ci:** pin reusable workflows to [@v2](https://github.com/v2).9.3 ([324cd96](https://github.com/teqbench/tbx-mat-banners/commit/324cd962d370d0a87264ffa8328c7410f91f58c9)), closes [#28](https://github.com/teqbench/tbx-mat-banners/issues/28)
+* **ci:** pin reusable workflows to v2.9.3 ([324cd96](https://github.com/teqbench/tbx-mat-banners/commit/324cd962d370d0a87264ffa8328c7410f91f58c9)), closes [#28](https://github.com/teqbench/tbx-mat-banners/issues/28)
 * **deps:** bump tbx-mat-icons and tbx-mat-severity-theme peerDeps ([bb08bf2](https://github.com/teqbench/tbx-mat-banners/commit/bb08bf27fec4849ceeef7fa534f557f6072a78d0))
 * **deps:** bump tbx-mat-icons and tbx-mat-severity-theme peerDeps ([bd70577](https://github.com/teqbench/tbx-mat-banners/commit/bd7057764567b80d09a85d0ed5a11f0d354efc95)), closes [#28](https://github.com/teqbench/tbx-mat-banners/issues/28)
 
@@ -14,9 +14,9 @@
 
 ### Bug Fixes
 
-* **ci:** pin reusable workflows to [@v2](https://github.com/v2).6.0 ([e8ac614](https://github.com/teqbench/tbx-mat-banners/commit/e8ac614a28c3102652ddb184a2c1306efd75e523))
-* **ci:** pin reusable workflows to [@v2](https://github.com/v2).6.0 + bump [@teqbench](https://github.com/teqbench) peerDeps ([eca3a38](https://github.com/teqbench/tbx-mat-banners/commit/eca3a38a3006a9af934d896ecadf149e5fa85723))
-* **deps:** bump [@teqbench](https://github.com/teqbench) peerDeps to latest patches ([b538dd6](https://github.com/teqbench/tbx-mat-banners/commit/b538dd6b08e73c0ca175b81f31355e837e01082e))
+* **ci:** pin reusable workflows to v2.6.0 ([e8ac614](https://github.com/teqbench/tbx-mat-banners/commit/e8ac614a28c3102652ddb184a2c1306efd75e523))
+* **ci:** pin reusable workflows to v2.6.0 + bump teqbench peerDeps ([eca3a38](https://github.com/teqbench/tbx-mat-banners/commit/eca3a38a3006a9af934d896ecadf149e5fa85723))
+* **deps:** bump teqbench peerDeps to latest patches ([b538dd6](https://github.com/teqbench/tbx-mat-banners/commit/b538dd6b08e73c0ca175b81f31355e837e01082e))
 
 ## [0.10.2](https://github.com/teqbench/tbx-mat-banners/compare/v0.10.1...v0.10.2) (2026-05-08)
 
@@ -214,7 +214,7 @@
 ### Bug Fixes
 
 * **security:** switch reporting channel to email for private template repo ([5d0309d](https://github.com/teqbench/teqbench.dev.templates.tbx-package/commit/5d0309dbb948341cd83a8f39e05cba4d6648ccf4))
-* **tsdoc:** set [@related](https://github.com/related) tag to allowMultiple matching CLAUDE.md convention ([3e346a2](https://github.com/teqbench/teqbench.dev.templates.tbx-package/commit/3e346a21c052ccbd02b76b49714a716d28238ad3))
+* **tsdoc:** set related tag to allowMultiple matching CLAUDE.md convention ([3e346a2](https://github.com/teqbench/teqbench.dev.templates.tbx-package/commit/3e346a21c052ccbd02b76b49714a716d28238ad3))
 
 ## [0.6.1](https://github.com/teqbench/teqbench.dev.templates.tbx-package/compare/v0.6.0...v0.6.1) (2026-03-25)
 
@@ -312,7 +312,7 @@
 
 ### Features
 
-* scaffold [@teqbench](https://github.com/teqbench) package template ([47fb9c7](https://github.com/teqbench/teqbench.dev.templates.tbx-package/commit/47fb9c7a708581e9d6188ceaef1ff1214938cc83))
+* scaffold teqbench package template ([47fb9c7](https://github.com/teqbench/teqbench.dev.templates.tbx-package/commit/47fb9c7a708581e9d6188ceaef1ff1214938cc83))
 * **template:** harden package template to production-grade ([20cd619](https://github.com/teqbench/teqbench.dev.templates.tbx-package/commit/20cd6191c9248171f3542b82c381e8ed5c5d1d20))
 * **template:** harden package template to production-grade ([b0ec3a2](https://github.com/teqbench/teqbench.dev.templates.tbx-package/commit/b0ec3a21eab0c23eb1ccfeed83908ba63db436a3))
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -273,6 +273,17 @@ Follow [**Conventional Commits** ↗](https://www.conventionalcommits.org) stric
 - `refactor(scope): ...` — Refactor
 - `chore(scope): ...` — Maintenance
 
+### No Bare At-Prefixed Tokens
+
+Do not write the at-symbol followed by a non-slashed identifier in commit subjects or bodies. The release-please changelog renderer ([conventional-changelog-conventionalcommits ↗](https://github.com/conventional-changelog/conventional-changelog) v6 `writerOpts.transform`) rewrites such tokens as broken GitHub user-mention links, splitting version strings into links to non-existent users.
+
+- Version refs: write `v2.9.3`, not preceded by the at-symbol.
+- Scope/org refs in prose: write `teqbench`, not preceded by the at-symbol.
+- TSDoc tag refs in prose: write `related`, `example`, `since`, `category`, `returns`, `link` — not preceded by the at-symbol.
+- Fully-qualified scoped package paths that contain a forward slash remain safe; the renderer short-circuits them.
+
+Markdown formatting does not escape this rewrite: backticks and code spans in commit messages do not protect.
+
 ## Branching & Workflow
 
 - `main` — Production. Only receives merges from `release/*`, `hotfix/*`, or `release-please--*` branches.


### PR DESCRIPTION
## Summary

- Strip broken GitHub user-mention autolinks injected by release-please's changelog renderer from CHANGELOG.md (7 historical entries).
- Add a CLAUDE.md section codifying the rule that bare at-prefixed tokens must not appear in commit subjects or bodies, with safe-form guidance for scoped package paths.

## Root cause

release-please uses `conventional-changelog-conventionalcommits@^6.0.0`. Its `writerOpts.transform` callback rewrites bare at-prefixed identifiers in commit subjects as GitHub user-mention links of the form `[at-x](https://github.com/x)`. The match terminates at the first `.` or `/`, so version strings written with a leading at-symbol get split — for example, a token like `v2.9.3` written with a leading at-symbol is rendered as a broken link to a non-existent `v2` user with `.9.3` left as bare text. The link wrapping is hardcoded; no release-please or preset configuration disables it.

## Why this is a `fix` and not `docs`

`CHANGELOG.md` is published in the npm tarball via `ng-package.json` asset config (`{"input": ".", "glob": "CHANGELOG.md", "output": "."}`) and consumed by the website's package introspection. A patch release is required for the corrected text to reach the website.

## Scope

This PR is the canary for an org-wide remediation across 15 affected repos. Confirming end-to-end behavior here (sed correctness, release-please PR rendering, published tarball content, website ingest) before fanning out to the remaining 14.

## Test plan

- [x] sed dry-run against all 15 affected CHANGELOGs verified — 61 total autolinks resolved, no false positives.
- [x] Format check passes locally (`npm run format:check`).
- [ ] Reviewer confirms diff is exactly the intended unwrap on the 7 affected lines.
- [ ] After merge to `dev`, carry to `main` via `release/*`; release-please opens its PR; reviewer confirms the new `## [0.10.5]` section in the release-please PR does NOT contain any `[at-x](...)` autolinks.
- [ ] Merge release-please PR, publish 0.10.5 to GitHub Packages.
- [ ] Verify `dist/CHANGELOG.md` in the published tarball matches the patched file.
- [ ] Verify the website's package introspection ingests the new CHANGELOG without error.