### PR TITLE
fix(deps): bump tbx-mat peerDep floors and advance .shared-skills (wave 4 of changelog remediation)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,8 +50,8 @@
         "@angular/cdk": ">=21.0.0",
         "@angular/core": ">=21.0.0",
         "@angular/material": ">=21.0.0",
-        "@teqbench/tbx-mat-icons": ">=4.2.2",
-        "@teqbench/tbx-mat-severity-theme": ">=8.0.4",
+        "@teqbench/tbx-mat-icons": ">=4.2.3",
+        "@teqbench/tbx-mat-severity-theme": ">=8.0.5",
         "rxjs": ">=7.0.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
     "@angular/cdk": ">=21.0.0",
     "@angular/core": ">=21.0.0",
     "@angular/material": ">=21.0.0",
-    "@teqbench/tbx-mat-icons": ">=4.2.2",
-    "@teqbench/tbx-mat-severity-theme": ">=8.0.4",
+    "@teqbench/tbx-mat-icons": ">=4.2.3",
+    "@teqbench/tbx-mat-severity-theme": ">=8.0.5",
     "rxjs": ">=7.0.0"
   },
   "devDependenciesPinned": {


### PR DESCRIPTION
## Summary

Wave 4 of the org-wide changelog autolink remediation for tbx-mat-banners. The CHANGELOG and CLAUDE.md changes for this repo were merged earlier as the canary (#171); this PR completes wave 4:

- Advance the `.shared-skills` submodule pointer to latest `main` (waves 0 and 1).
- Bump `@teqbench/tbx-mat-icons` peerDep floor `>=4.2.2` → `>=4.2.3` (wave 2 release).
- Bump `@teqbench/tbx-mat-severity-theme` peerDep floor `>=8.0.4` → `>=8.0.5` (wave 3 release).
- Refresh `package-lock.json` for the new peerDep ranges.

When this PR merges to `dev` and dev is carried to `main` via `release/*`, the resulting release-please tag will publish the combined canary changelog/CLAUDE.md fix and wave 4 dep bumps in a single patch release.

## Wave 4 of org-wide remediation

| Wave | Repo | Status |
|---|---|---|
| canary | tbx-mat-banners (changelog/CLAUDE.md on dev) | release combined into wave 4 |
| 0 | teqbench.dev.misc-skills | released to main |
| 1 | teqbench.dev.shared-skills | released to main |
| 2 | tbx-models, tbx-ngx-errors, tbx-ngx-http, tbx-mat-icons | released to main |
| 3 | tbx-mat-severity-theme | released to main |
| **4** | **tbx-mat-{notifications, banners (this PR), bottom-sheets, dialogs}** | **in progress** |
| 5 | teqbench.app.{website, liists.webapp, tradingtoolbox.webapp} | pending |
| 6 | teqbench.dev.templates.tbx-package | pending |

## Test plan

- [ ] Reviewer confirms diff: `.shared-skills` advance, peerDep floor bumps, lockfile refresh.
- [ ] Merge to `dev`; carry to `main` via `release/*`; release-please opens its PR.
- [ ] Reviewer confirms the new release-please section does NOT contain `[at-x](...)` autolinks.
- [ ] Merge release-please PR.